### PR TITLE
Fix attaching multiple disk error and remove 'device_name'

### DIFF
--- a/alicloud.tf
+++ b/alicloud.tf
@@ -1,45 +1,85 @@
-variable "region" {
-  default = "cn-beijing"
+//variable "region" {
+//  default = "cn-beijing"
+//}
+//
+//variable "ecs_password" {
+//  default = "Test12345"
+//}
+//
+//variable "worker_count" {
+//  default = "1"
+//}
+//variable "worker_count_format" {
+//  default = "%03d"
+//}
+//variable "worker_ecs_type" {
+//  default = "ecs.n1.small"
+//}
+//
+//variable "short_name" {
+//  default = "hi"
+//}
+//
+//variable "internet_charge_type" {
+//  default = "PayByTraffic"
+//}
+//
+//variable "datacenter" {
+//  default = "beijing"
+//}
+//
+//provider "alicloud" {
+//  region = "${var.region}"
+//}
+//
+//module "worker-nodes" {
+//  source = "./terraform/examples/alicloud-ecs"
+//  count = "${var.worker_count}"
+//  count_format = "${var.worker_count_format}"
+//  role = "worker"
+//  datacenter = "${var.datacenter}"
+//  ecs_type = "${var.worker_ecs_type}"
+//  ecs_password = "${var.ecs_password}"
+//  short_name = "${var.short_name}"
+//  internet_charge_type = "${var.internet_charge_type}"
+//}
+
+variable "count" {
+  default = "2"
 }
 
-variable "ecs_password" {
-  default = "Test12345"
+variable "per_count" {
+  default = "2"
 }
 
-variable "worker_count" {
-  default = "1"
-}
-variable "worker_count_format" {
-  default = "%03d"
-}
-variable "worker_ecs_type" {
-  default = "ecs.n1.small"
+resource "alicloud_security_group" "group" {
+  name = "terraform-test-group"
+  description = "New security group"
 }
 
-variable "short_name" {
-  default = "hi"
+resource "alicloud_instance" "workers" {
+  count = "${var.count}"
+  image_id = "ubuntu_140405_64_40G_cloudinit_20161115.vhd"
+  instance_type = "ecs.n1.tiny"
+  availability_zone = "cn-beijing-a"
+  security_groups = ["${alicloud_security_group.group.id}"]
+  instance_name = "hello"
+  internet_charge_type = "PayByBandwidth"
+  io_optimized = "optimized"
+  system_disk_category = "cloud_efficiency"
+  security_groups = ["${alicloud_security_group.group.id}"]
+
 }
 
-variable "internet_charge_type" {
-  default = "PayByTraffic"
+resource "alicloud_disk" "disk" {
+  count = "${var.per_count * var.count}"
+  availability_zone = "cn-beijing-a"
+  category          = "cloud_ssd"
+  size              = "50"
 }
 
-variable "datacenter" {
-  default = "beijing"
-}
-
-provider "alicloud" {
-  region = "${var.region}"
-}
-
-module "worker-nodes" {
-  source = "./terraform/examples/alicloud-ecs"
-  count = "${var.worker_count}"
-  count_format = "${var.worker_count_format}"
-  role = "worker"
-  datacenter = "${var.datacenter}"
-  ecs_type = "${var.worker_ecs_type}"
-  ecs_password = "${var.ecs_password}"
-  short_name = "${var.short_name}"
-  internet_charge_type = "${var.internet_charge_type}"
+resource "alicloud_disk_attachment" "worker-disk-attach" {
+  count = "${var.per_count * var.count}"
+  disk_id     = "${element(alicloud_disk.disk.*.id, count.index)}"
+  instance_id = "${element(alicloud_instance.workers.*.id, count.index / var.count)}"
 }

--- a/alicloud.tf
+++ b/alicloud.tf
@@ -1,85 +1,45 @@
-//variable "region" {
-//  default = "cn-beijing"
-//}
-//
-//variable "ecs_password" {
-//  default = "Test12345"
-//}
-//
-//variable "worker_count" {
-//  default = "1"
-//}
-//variable "worker_count_format" {
-//  default = "%03d"
-//}
-//variable "worker_ecs_type" {
-//  default = "ecs.n1.small"
-//}
-//
-//variable "short_name" {
-//  default = "hi"
-//}
-//
-//variable "internet_charge_type" {
-//  default = "PayByTraffic"
-//}
-//
-//variable "datacenter" {
-//  default = "beijing"
-//}
-//
-//provider "alicloud" {
-//  region = "${var.region}"
-//}
-//
-//module "worker-nodes" {
-//  source = "./terraform/examples/alicloud-ecs"
-//  count = "${var.worker_count}"
-//  count_format = "${var.worker_count_format}"
-//  role = "worker"
-//  datacenter = "${var.datacenter}"
-//  ecs_type = "${var.worker_ecs_type}"
-//  ecs_password = "${var.ecs_password}"
-//  short_name = "${var.short_name}"
-//  internet_charge_type = "${var.internet_charge_type}"
-//}
-
-variable "count" {
-  default = "2"
+variable "region" {
+  default = "cn-beijing"
 }
 
-variable "per_count" {
-  default = "2"
+variable "ecs_password" {
+  default = "Test12345"
 }
 
-resource "alicloud_security_group" "group" {
-  name = "terraform-test-group"
-  description = "New security group"
+variable "worker_count" {
+  default = "1"
+}
+variable "worker_count_format" {
+  default = "%03d"
+}
+variable "worker_ecs_type" {
+  default = "ecs.n1.small"
 }
 
-resource "alicloud_instance" "workers" {
-  count = "${var.count}"
-  image_id = "ubuntu_140405_64_40G_cloudinit_20161115.vhd"
-  instance_type = "ecs.n1.tiny"
-  availability_zone = "cn-beijing-a"
-  security_groups = ["${alicloud_security_group.group.id}"]
-  instance_name = "hello"
-  internet_charge_type = "PayByBandwidth"
-  io_optimized = "optimized"
-  system_disk_category = "cloud_efficiency"
-  security_groups = ["${alicloud_security_group.group.id}"]
-
+variable "short_name" {
+  default = "hi"
 }
 
-resource "alicloud_disk" "disk" {
-  count = "${var.per_count * var.count}"
-  availability_zone = "cn-beijing-a"
-  category          = "cloud_ssd"
-  size              = "50"
+variable "internet_charge_type" {
+  default = "PayByTraffic"
 }
 
-resource "alicloud_disk_attachment" "worker-disk-attach" {
-  count = "${var.per_count * var.count}"
-  disk_id     = "${element(alicloud_disk.disk.*.id, count.index)}"
-  instance_id = "${element(alicloud_instance.workers.*.id, count.index / var.count)}"
+variable "datacenter" {
+  default = "beijing"
+}
+
+provider "alicloud" {
+  region = "${var.region}"
+}
+
+module "worker-nodes" {
+  source = "./terraform/examples/alicloud-ecs"
+  count = "${var.worker_count}"
+  count_format = "${var.worker_count_format}"
+  role = "worker"
+  datacenter = "${var.datacenter}"
+  ecs_type = "${var.worker_ecs_type}"
+  ecs_password = "${var.ecs_password}"
+  short_name = "${var.short_name}"
+  internet_charge_type = "${var.internet_charge_type}"
 }

--- a/alicloud/errors.go
+++ b/alicloud/errors.go
@@ -16,6 +16,7 @@ const (
 	DiskCreatingSnapshot      = "DiskCreatingSnapshot"
 	InstanceLockedForSecurity = "InstanceLockedForSecurity"
 	SystemDiskNotFound        = "SystemDiskNotFound"
+	DiskOperationConflict     = "OperationConflict"
 	// eip
 	EipIncorrectStatus      = "IncorrectEipStatus"
 	InstanceIncorrectStatus = "IncorrectInstanceStatus"

--- a/alicloud/resource_alicloud_disk_attachment.go
+++ b/alicloud/resource_alicloud_disk_attachment.go
@@ -31,10 +31,11 @@ func resourceAliyunDiskAttachment() *schema.Resource {
 			},
 
 			"device_name": &schema.Schema{
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-				ForceNew: true,
+				Type:       schema.TypeString,
+				Optional:   true,
+				ForceNew:   true,
+				Computed:   true,
+				Deprecated: "Attribute device_name is deprecated on disk attachment resource. Suggest to remove it from your template.",
 			},
 		},
 	}

--- a/terraform/examples/alicloud-ecs-image/main.tf
+++ b/terraform/examples/alicloud-ecs-image/main.tf
@@ -83,6 +83,5 @@ resource "alicloud_disk_attachment" "instance-attachment" {
   count = "${var.count}"
   disk_id = "${element(alicloud_disk.disk.*.id, count.index)}"
   instance_id = "${element(alicloud_instance.instance.*.id, count.index)}"
-  device_name = "${var.device_name}"
 }
 

--- a/terraform/examples/alicloud-ecs-image/variables.tf
+++ b/terraform/examples/alicloud-ecs-image/variables.tf
@@ -32,7 +32,7 @@ variable "ecs_password" {
   default = "Test12345"
 }
 variable "availability_zones" {
-  default = "cn-beijing-b"
+  default = "cn-beijing-a"
 }
 variable "allocate_public_ip" {
   default = true
@@ -51,7 +51,4 @@ variable "disk_category" {
 }
 variable "disk_size" {
   default = "40"
-}
-variable "device_name" {
-  default = "/dev/xvdb"
 }

--- a/terraform/examples/alicloud-ecs-vpc/main.tf
+++ b/terraform/examples/alicloud-ecs-vpc/main.tf
@@ -39,7 +39,6 @@ resource "alicloud_disk_attachment" "instance-attachment" {
   count = "${var.count}"
   disk_id = "${element(alicloud_disk.disk.*.id, count.index)}"
   instance_id = "${element(alicloud_instance.instance.*.id, count.index)}"
-  device_name = "${var.device_name}"
 }
 
 

--- a/terraform/examples/alicloud-ecs-vpc/variables.tf
+++ b/terraform/examples/alicloud-ecs-vpc/variables.tf
@@ -59,9 +59,6 @@ variable "disk_category" {
 variable "disk_size" {
   default = "40"
 }
-variable "device_name" {
-  default = "/dev/xvdb"
-}
 
 variable "vswitch_id" {
   default = ""

--- a/terraform/examples/alicloud-ecs/main.tf
+++ b/terraform/examples/alicloud-ecs/main.tf
@@ -72,5 +72,4 @@ resource "alicloud_disk_attachment" "instance-attachment" {
   count = "${var.count}"
   disk_id = "${element(alicloud_disk.disk.*.id, count.index)}"
   instance_id = "${element(alicloud_instance.instance.*.id, count.index)}"
-  device_name = "${var.device_name}"
 }

--- a/terraform/examples/alicloud-ecs/variables.tf
+++ b/terraform/examples/alicloud-ecs/variables.tf
@@ -47,9 +47,6 @@ variable "disk_category" {
 variable "disk_size" {
   default = "40"
 }
-variable "device_name" {
-  default = "/dev/xvdb"
-}
 
 variable "nic_type" {
   default = "internet"


### PR DESCRIPTION
The PR improve disk_attachment resource from the following aspects:

1. Add waitForDisksInUse method to fix attaching multiple disk error;
2. Set disk attachment resource's 'device_name' to 'Deprecated'
3. Remove device_name variable from examples and testcase.