### PR TITLE
improve instance_type and device for ess scaling configuration

### DIFF
--- a/alicloud/resource_alicloud_disk_attachment_test.go
+++ b/alicloud/resource_alicloud_disk_attachment_test.go
@@ -178,12 +178,11 @@ resource "alicloud_disk" "disk" {
 
 resource "alicloud_instance" "instance" {
   image_id = "ubuntu_140405_64_40G_cloudinit_20161115.vhd"
-  instance_type = "ecs.s1.small"
+  instance_type = "ecs.n4.small"
   availability_zone = "cn-beijing-a"
   security_groups = ["${alicloud_security_group.group.id}"]
   instance_name = "hello"
   internet_charge_type = "PayByBandwidth"
-  io_optimized = "none"
 
   tags {
     Name = "TerraformTest-instance"
@@ -218,12 +217,11 @@ resource "alicloud_disk" "disks" {
 
 resource "alicloud_instance" "instance" {
   image_id = "ubuntu_140405_64_40G_cloudinit_20161115.vhd"
-  instance_type = "ecs.s1.small"
+  instance_type = "ecs.n4.small"
   availability_zone = "cn-beijing-a"
   security_groups = ["${alicloud_security_group.group.id}"]
   instance_name = "hello"
   internet_charge_type = "PayByBandwidth"
-  io_optimized = "none"
 
   tags {
     Name = "TerraformTest-instance"

--- a/alicloud/resource_alicloud_eip_association_test.go
+++ b/alicloud/resource_alicloud_eip_association_test.go
@@ -129,9 +129,8 @@ resource "alicloud_instance" "instance" {
   vswitch_id = "${alicloud_vswitch.main.id}"
   image_id = "ubuntu_140405_32_40G_cloudinit_20161115.vhd"
 
-  # series II
-  instance_type = "ecs.n1.medium"
-  io_optimized = "optimized"
+  # series III
+  instance_type = "ecs.n4.large"
   system_disk_category = "cloud_efficiency"
 
   security_groups = ["${alicloud_security_group.group.id}"]

--- a/alicloud/resource_alicloud_ess_scalingconfiguration_test.go
+++ b/alicloud/resource_alicloud_ess_scalingconfiguration_test.go
@@ -34,7 +34,7 @@ func TestAccAlicloudEssScalingConfiguration_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"alicloud_ess_scaling_configuration.foo",
 						"instance_type",
-						"ecs.s2.large"),
+						"ecs.n4.large"),
 					resource.TestMatchResourceAttr(
 						"alicloud_ess_scaling_configuration.foo",
 						"image_id",
@@ -71,7 +71,7 @@ func TestAccAlicloudEssScalingConfiguration_multiConfig(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"alicloud_ess_scaling_configuration.bar",
 						"instance_type",
-						"ecs.s2.large"),
+						"ecs.n4.large"),
 					resource.TestMatchResourceAttr(
 						"alicloud_ess_scaling_configuration.bar",
 						"image_id",
@@ -108,7 +108,7 @@ func SkipTestAccAlicloudEssScalingConfiguration_active(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"alicloud_ess_scaling_configuration.bar",
 						"instance_type",
-						"ecs.s2.large"),
+						"ecs.n4.large"),
 					resource.TestMatchResourceAttr(
 						"alicloud_ess_scaling_configuration.bar",
 						"image_id",
@@ -128,7 +128,7 @@ func SkipTestAccAlicloudEssScalingConfiguration_active(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"alicloud_ess_scaling_configuration.bar",
 						"instance_type",
-						"ecs.s2.large"),
+						"ecs.n4.large"),
 					resource.TestMatchResourceAttr(
 						"alicloud_ess_scaling_configuration.bar",
 						"image_id",
@@ -165,7 +165,7 @@ func SkipTestAccAlicloudEssScalingConfiguration_enable(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"alicloud_ess_scaling_configuration.foo",
 						"instance_type",
-						"ecs.s2.large"),
+						"ecs.n4.large"),
 					resource.TestMatchResourceAttr(
 						"alicloud_ess_scaling_configuration.foo",
 						"image_id",
@@ -185,7 +185,7 @@ func SkipTestAccAlicloudEssScalingConfiguration_enable(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"alicloud_ess_scaling_configuration.foo",
 						"instance_type",
-						"ecs.s2.large"),
+						"ecs.n4.large"),
 					resource.TestMatchResourceAttr(
 						"alicloud_ess_scaling_configuration.foo",
 						"image_id",
@@ -285,8 +285,7 @@ resource "alicloud_ess_scaling_configuration" "foo" {
 	scaling_group_id = "${alicloud_ess_scaling_group.foo.id}"
 
 	image_id = "${data.alicloud_images.ecs_image.images.0.id}"
-	instance_type = "ecs.s2.large"
-	io_optimized = "optimized"
+	instance_type = "ecs.n4.large"
 	security_group_id = "${alicloud_security_group.tf_test_foo.id}"
 }
 `
@@ -323,8 +322,7 @@ resource "alicloud_ess_scaling_configuration" "foo" {
 	scaling_group_id = "${alicloud_ess_scaling_group.foo.id}"
 
 	image_id = "${data.alicloud_images.ecs_image.images.0.id}"
-	instance_type = "ecs.s2.large"
-	io_optimized = "optimized"
+	instance_type = "ecs.n4.large"
 	security_group_id = "${alicloud_security_group.tf_test_foo.id}"
 }
 
@@ -332,8 +330,7 @@ resource "alicloud_ess_scaling_configuration" "bar" {
 	scaling_group_id = "${alicloud_ess_scaling_group.foo.id}"
 
 	image_id = "${data.alicloud_images.ecs_image.images.0.id}"
-	instance_type = "ecs.s2.large"
-	io_optimized = "optimized"
+	instance_type = "ecs.n4.large"
 	security_group_id = "${alicloud_security_group.tf_test_foo.id}"
 }
 `
@@ -371,8 +368,7 @@ resource "alicloud_ess_scaling_configuration" "foo" {
 	active = true
 
 	image_id = "${data.alicloud_images.ecs_image.images.0.id}"
-	instance_type = "ecs.s2.large"
-	io_optimized = "optimized"
+	instance_type = "ecs.n4.large"
 	security_group_id = "${alicloud_security_group.tf_test_foo.id}"
 }
 `
@@ -410,8 +406,7 @@ resource "alicloud_ess_scaling_configuration" "foo" {
 	active = false
 
 	image_id = "${data.alicloud_images.ecs_image.images.0.id}"
-	instance_type = "ecs.s2.large"
-	io_optimized = "optimized"
+	instance_type = "ecs.n4.large"
 	security_group_id = "${alicloud_security_group.tf_test_foo.id}"
 }
 `
@@ -449,8 +444,7 @@ resource "alicloud_ess_scaling_configuration" "foo" {
 	enable = true
 
 	image_id = "${data.alicloud_images.ecs_image.images.0.id}"
-	instance_type = "ecs.s2.large"
-	io_optimized = "optimized"
+	instance_type = "ecs.n4.large"
 	security_group_id = "${alicloud_security_group.tf_test_foo.id}"
 }
 `
@@ -488,8 +482,7 @@ resource "alicloud_ess_scaling_configuration" "foo" {
 	enable = false
 
 	image_id = "${data.alicloud_images.ecs_image.images.0.id}"
-	instance_type = "ecs.s2.large"
-	io_optimized = "optimized"
+	instance_type = "ecs.n4.large"
 	security_group_id = "${alicloud_security_group.tf_test_foo.id}"
 }
 `

--- a/alicloud/resource_alicloud_ess_scalinggroup_test.go
+++ b/alicloud/resource_alicloud_ess_scalinggroup_test.go
@@ -287,8 +287,7 @@ resource "alicloud_ess_scaling_configuration" "foo" {
 	enable = true
 
 	image_id = "${data.alicloud_images.ecs_image.images.0.id}"
-	instance_type = "ecs.n1.medium"
-	io_optimized = "optimized"
+	instance_type = "ecs.n4.large"
 	system_disk_category = "cloud_efficiency"
 	internet_charge_type = "PayByTraffic"
 	internet_max_bandwidth_out = 10

--- a/alicloud/resource_alicloud_ess_scalingrule_test.go
+++ b/alicloud/resource_alicloud_ess_scalingrule_test.go
@@ -186,8 +186,7 @@ resource "alicloud_ess_scaling_configuration" "foo" {
 	scaling_group_id = "${alicloud_ess_scaling_group.bar.id}"
 
 	image_id = "${data.alicloud_images.ecs_image.images.0.id}"
-	instance_type = "ecs.s2.large"
-	io_optimized = "optimized"
+	instance_type = "ecs.n4.large"
 	security_group_id = "${alicloud_security_group.tf_test_foo.id}"
 }
 
@@ -231,8 +230,7 @@ resource "alicloud_ess_scaling_configuration" "foo" {
 	scaling_group_id = "${alicloud_ess_scaling_group.bar.id}"
 
 	image_id = "${data.alicloud_images.ecs_image.images.0.id}"
-	instance_type = "ecs.s2.large"
-	io_optimized = "optimized"
+	instance_type = "ecs.n4.large"
 	security_group_id = "${alicloud_security_group.tf_test_foo.id}"
 }
 
@@ -276,8 +274,7 @@ resource "alicloud_ess_scaling_configuration" "foo" {
 	scaling_group_id = "${alicloud_ess_scaling_group.bar.id}"
 
 	image_id = "${data.alicloud_images.ecs_image.images.0.id}"
-	instance_type = "ecs.s2.large"
-	io_optimized = "optimized"
+	instance_type = "ecs.n4.large"
 	security_group_id = "${alicloud_security_group.tf_test_foo.id}"
 }
 

--- a/alicloud/resource_alicloud_ess_schedule_test.go
+++ b/alicloud/resource_alicloud_ess_schedule_test.go
@@ -131,8 +131,7 @@ resource "alicloud_ess_scaling_configuration" "foo" {
 	scaling_group_id = "${alicloud_ess_scaling_group.bar.id}"
 
 	image_id = "${data.alicloud_images.ecs_image.images.0.id}"
-	instance_type = "ecs.s2.large"
-	io_optimized = "optimized"
+	instance_type = "ecs.n4.large"
 	security_group_id = "${alicloud_security_group.tf_test_foo.id}"
 }
 

--- a/alicloud/resource_alicloud_instance.go
+++ b/alicloud/resource_alicloud_instance.go
@@ -94,7 +94,7 @@ func resourceAliyunInstance() *schema.Resource {
 			"io_optimized": &schema.Schema{
 				Type:       schema.TypeString,
 				Optional:   true,
-				Deprecated: "Attribute io_optimized is deprecated on instance resource. All the alicloud instances are IO optimized. Suggest to remove it from your template.",
+				Deprecated: "Attribute io_optimized is deprecated on instance resource. All the launched alicloud instances are IO optimized. Suggest to remove it from your template.",
 			},
 
 			"system_disk_category": &schema.Schema{

--- a/alicloud/resource_alicloud_slb_attachment_test.go
+++ b/alicloud/resource_alicloud_slb_attachment_test.go
@@ -105,12 +105,11 @@ resource "alicloud_instance" "foo" {
 	# cn-beijing
 	image_id = "ubuntu_140405_64_40G_cloudinit_20161115.vhd"
 
-	# series II
-	instance_type = "ecs.n1.medium"
+	# series III
+	instance_type = "ecs.n4.large"
 	internet_charge_type = "PayByBandwidth"
 	internet_max_bandwidth_out = "5"
 	system_disk_category = "cloud_efficiency"
-	io_optimized = "optimized"
 
 	security_groups = ["${alicloud_security_group.foo.id}"]
 	instance_name = "test_foo"

--- a/alicloud/resource_alicloud_vroute_entry_test.go
+++ b/alicloud/resource_alicloud_vroute_entry_test.go
@@ -167,12 +167,11 @@ resource "alicloud_instance" "foo" {
 	vswitch_id = "${alicloud_vswitch.foo.id}"
 	allocate_public_ip = true
 
-	# series II
+	# series III
 	instance_charge_type = "PostPaid"
-	instance_type = "ecs.n1.small"
+	instance_type = "ecs.n4.small"
 	internet_charge_type = "PayByTraffic"
 	internet_max_bandwidth_out = 5
-	io_optimized = "optimized"
 
 	system_disk_category = "cloud_efficiency"
 	image_id = "ubuntu_140405_64_40G_cloudinit_20161115.vhd"

--- a/terraform/examples/alicloud-ess-scaling/main.tf
+++ b/terraform/examples/alicloud-ess-scaling/main.tf
@@ -33,6 +33,5 @@ resource "alicloud_ess_scaling_configuration" "config" {
 
   image_id = "${data.alicloud_images.ecs_image.images.0.id}"
   instance_type = "${var.ecs_instance_type}"
-  io_optimized = "optimized"
   security_group_id = "${alicloud_security_group.sg.id}"
 }

--- a/terraform/examples/alicloud-ess-schedule/main.tf
+++ b/terraform/examples/alicloud-ess-schedule/main.tf
@@ -33,7 +33,6 @@ resource "alicloud_ess_scaling_configuration" "config" {
 
   image_id = "${data.alicloud_images.ecs_image.images.0.id}"
   instance_type = "${var.ecs_instance_type}"
-  io_optimized = "optimized"
   security_group_id = "${alicloud_security_group.sg.id}"
 }
 
@@ -47,5 +46,5 @@ resource "alicloud_ess_scaling_rule" "rule" {
 resource "alicloud_ess_schedule" "run" {
   scheduled_action = "${alicloud_ess_scaling_rule.rule.ari}"
   launch_time = "${var.schedule_launch_time}"
-  scheduled_task_name = "tf-run"
+  scheduled_task_name = "tf-run-foo"
 }

--- a/terraform/examples/alicloud-ess-schedule/variables.tf
+++ b/terraform/examples/alicloud-ess-schedule/variables.tf
@@ -28,5 +28,5 @@ variable "rule_adjust_size" {
 }
 
 variable "schedule_launch_time" {
-  default = "2017-04-01T01:59Z"
+  default = "2017-07-07T04:22Z"
 }


### PR DESCRIPTION
1. set ess scaling configuation instance's io_optimized to deprecated
2. set ess scaling configuation disk's device to deprecated 
3. add instance_type filter for ess scaling configuation
4. remove io_optimiezd and invalid instance_type in the testcase