### PR TITLE
-Modify some word misspellings

### DIFF
--- a/alicloud/extension_slb.go
+++ b/alicloud/extension_slb.go
@@ -49,7 +49,7 @@ func expandListeners(configured []interface{}) ([]*Listener, error) {
 	listeners := make([]*Listener, 0, len(configured))
 
 	// Loop over our configured listeners and create
-	// an array of aws-sdk-go compatabile objects
+	// an array of aws-sdk-go compatible objects
 	for _, lRaw := range configured {
 		data := lRaw.(map[string]interface{})
 

--- a/alicloud/resource_alicloud_ram_group_policy_attachment_test.go
+++ b/alicloud/resource_alicloud_ram_group_policy_attachment_test.go
@@ -48,7 +48,7 @@ func testAccCheckRamGroupPolicyAttachmentExists(n string, policy *ram.Policy, gr
 		}
 
 		if rs.Primary.ID == "" {
-			return fmt.Errorf("No Atatchment ID is set")
+			return fmt.Errorf("No Attachment ID is set")
 		}
 
 		client := testAccProvider.Meta().(*AliyunClient)

--- a/alicloud/resource_alicloud_ram_role_policy_attachment_test.go
+++ b/alicloud/resource_alicloud_ram_role_policy_attachment_test.go
@@ -48,7 +48,7 @@ func testAccCheckRamRolePolicyAttachmentExists(n string, policy *ram.Policy, rol
 		}
 
 		if rs.Primary.ID == "" {
-			return fmt.Errorf("No Atatchment ID is set")
+			return fmt.Errorf("No Attachment ID is set")
 		}
 
 		client := testAccProvider.Meta().(*AliyunClient)

--- a/alicloud/resource_alicloud_ram_user_policy_attachment_test.go
+++ b/alicloud/resource_alicloud_ram_user_policy_attachment_test.go
@@ -48,7 +48,7 @@ func testAccCheckRamUserPolicyAttachmentExists(n string, policy *ram.Policy, use
 		}
 
 		if rs.Primary.ID == "" {
-			return fmt.Errorf("No Atatchment ID is set")
+			return fmt.Errorf("No Attachment ID is set")
 		}
 
 		client := testAccProvider.Meta().(*AliyunClient)

--- a/alicloud/service_alicloud_ecs.go
+++ b/alicloud/service_alicloud_ecs.go
@@ -289,7 +289,7 @@ func (client *AliyunClient) CheckParameterValidity(d *schema.ResourceData, meta 
 		validZones = append(validZones, zone.ZoneId)
 	}
 	if zoneId != "" && !valid {
-		return nil, fmt.Errorf("Availablity zone %s is not supported in the region %s. Expected availablity zones: %s.",
+		return nil, fmt.Errorf("Availability zone %s is not supported in the region %s. Expected availability zones: %s.",
 			zoneId, getRegion(d, meta), strings.Join(validZones, ", "))
 	}
 


### PR DESCRIPTION
1	github.com/alibaba/terraform-provider/alicloud/extension_slb.go:52:27	"compatabile" is a misspelling of "compatible"
2	github.com/alibaba/terraform-provider/alicloud/resource_alicloud_ram_group_policy_attachment_test.go:51:25	"Atatchment" is a misspelling of "Attachment"
3	github.com/alibaba/terraform-provider/alicloud/resource_alicloud_ram_role_policy_attachment_test.go:51:25	"Atatchment" is a misspelling of "Attachment"
4	github.com/alibaba/terraform-provider/alicloud/resource_alicloud_ram_user_policy_attachment_test.go:51:25	"Atatchment" is a misspelling of "Attachment"
5	github.com/alibaba/terraform-provider/alicloud/service_alicloud_ecs.go:292:26	"Availablity" is a misspelling of "Availability"
6	github.com/alibaba/terraform-provider/alicloud/service_alicloud_ecs.go:292:90	"availablity" is a misspelling of "availability"