### PR TITLE
Allow InternetMaxBandwidthOut=0

### DIFF
--- a/alicloud/resource_alicloud_ess_scalingconfiguration.go
+++ b/alicloud/resource_alicloud_ess_scalingconfiguration.go
@@ -426,9 +426,8 @@ func buildAlicloudEssScalingConfigurationArgs(d *schema.ResourceData, meta inter
 		args.InternetMaxBandwidthIn = v
 	}
 
-	if v := d.Get("internet_max_bandwidth_out").(int); v != 0 {
-		args.InternetMaxBandwidthOut = v
-	}
+	internetMaxBandwidthOut := d.Get("internet_max_bandwidth_out").(int)
+	args.InternetMaxBandwidthOut = &internetMaxBandwidthOut
 
 	if v := d.Get("system_disk_category").(string); v != "" {
 		args.SystemDisk_Category = common.UnderlineString(v)


### PR DESCRIPTION
Allow setting MaxBandwidthOut to 0 so we can launch scaling groups instances without public IPs.
There is a an additional matching pull request on https://github.com/denverdino/aliyungo/pull/250