### PR TITLE
remove ForceNew property for instance_charge_type

### DIFF
--- a/alicloud/resource_alicloud_db_instance.go
+++ b/alicloud/resource_alicloud_db_instance.go
@@ -61,7 +61,6 @@ func resourceAlicloudDBInstance() *schema.Resource {
 				Type:         schema.TypeString,
 				ValidateFunc: validateAllowedStringValue([]string{string(Postpaid), string(Prepaid)}),
 				Optional:     true,
-				ForceNew:     true,
 				Default:      Postpaid,
 			},
 


### PR DESCRIPTION
1. If rerun RDS instance, the resource will be destroyed and recreated as RDS SDK always return the nil value of `instance_charge_type` no matter what the input is.
2. ECS, SLB, and other resource doesn't treat `charge type` as a parameter which will result in the recreation of a resource.

So I request to remove `ForceNew` property for instance_charge_type of resource `db_instance`.