### PR TITLE
Allow 0 node count in Container Service cluster

### DIFF
--- a/alicloud/resource_alicloud_cs_swarm.go
+++ b/alicloud/resource_alicloud_cs_swarm.go
@@ -45,7 +45,7 @@ func resourceAlicloudCSSwarm() *schema.Resource {
 				Type:         schema.TypeInt,
 				Optional:     true,
 				Default:      1,
-				ValidateFunc: validateIntegerInRange(1, 50),
+				ValidateFunc: validateIntegerInRange(0, 50),
 			},
 			"cidr_block": &schema.Schema{
 				Type:     schema.TypeString,


### PR DESCRIPTION
CS allows creating clusters with 0 nodes. The reason I need this is because I want to explicitly create ECS instances and join them to the cluster since this gives me more control and options over the instances.