### PR TITLE
Removed localization to Hangzhou for Multi-AZ DB test

### DIFF
--- a/alicloud/resource_alicloud_db_instance_test.go
+++ b/alicloud/resource_alicloud_db_instance_test.go
@@ -332,9 +332,6 @@ resource "alicloud_db_instance" "foo" {
 }
 `
 const testAccDBInstance_multiAZ = `
-provider "alicloud" {
-  region = "cn-shanghai"
-}
 
 data "alicloud_zones" "default" {
   available_resource_creation= "Rds"


### PR DESCRIPTION
Make the test TestAccAlicloudDBInstance_multiAZ to be able to run outside of China.