### PR TITLE
New status in datasource alicloud eips

### DIFF
--- a/alicloud/data_source_alicloud_eips.go
+++ b/alicloud/data_source_alicloud_eips.go
@@ -33,6 +33,11 @@ func dataSourceAlicloudEips() *schema.Resource {
 				ForceNew: true,
 				MinItems: 1,
 			},
+			"status": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
 			"output_file": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -87,6 +92,7 @@ func dataSourceAlicloudEipsRead(d *schema.ResourceData, meta interface{}) error 
 
 	args := vpc.CreateDescribeEipAddressesRequest()
 	args.RegionId = string(getRegion(d, meta))
+	args.Status = d.Get("status").(string)
 	args.PageSize = requests.NewInteger(PageSizeLarge)
 
 	idsMap := make(map[string]string)

--- a/alicloud/data_source_alicloud_eips_test.go
+++ b/alicloud/data_source_alicloud_eips_test.go
@@ -26,6 +26,31 @@ func TestAccAlicloudEIPsDataSource(t *testing.T) {
 	})
 }
 
+func TestAccAlicloudEIPsDataSourceWithStatus(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckAlicloudEipsDataSourceWithStatusConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAlicloudDataSourceID("data.alicloud_eips.availableEips"),
+					resource.TestCheckResourceAttr("data.alicloud_eips.availableEips", "eips.#", "1"),
+					resource.TestCheckResourceAttr("data.alicloud_eips.availableEips", "eips.0.status", "Available"),
+					resource.TestCheckResourceAttr("data.alicloud_eips.availableEips", "eips.0.bandwidth", "10"),
+
+					testAccCheckAlicloudDataSourceID("data.alicloud_eips.inUseEips"),
+					resource.TestCheckResourceAttr("data.alicloud_eips.inUseEips", "eips.#", "1"),
+					resource.TestCheckResourceAttr("data.alicloud_eips.inUseEips", "eips.0.status", "InUse"),
+					resource.TestCheckResourceAttr("data.alicloud_eips.inUseEips", "eips.0.bandwidth", "5"),
+				),
+			},
+		},
+	})
+}
+
 const testAccCheckAlicloudEipsDataSourceConfig = `
 resource "alicloud_eip" "eip" {
   count = 2
@@ -35,5 +60,46 @@ resource "alicloud_eip" "eip" {
 data "alicloud_eips" "foo" {
   ids = ["${alicloud_eip.eip.*.id}"]
   ip_addresses = ["${alicloud_eip.eip.*.ip_address}"]
+}
+`
+
+const testAccCheckAlicloudEipsDataSourceWithStatusConfig = `
+resource "alicloud_eip" "availableEip" {
+  bandwidth = 10
+}
+resource "alicloud_eip" "inUseEip" {
+  bandwidth = 5
+}
+
+data "alicloud_zones" "zones" {
+  "available_resource_creation" = "VSwitch"
+}
+resource "alicloud_vpc" "vpc" {
+  name = "testAccCheckAlicloudEipsDataSourceWithStatusConfig"
+  cidr_block = "10.1.0.0/21"
+}
+resource "alicloud_vswitch" "vswitch" {
+  vpc_id = "${alicloud_vpc.vpc.id}"
+  cidr_block = "10.1.1.0/24"
+  availability_zone = "${data.alicloud_zones.zones.zones.0.id}"
+  name = "testAccCheckAlicloudEipsDataSourceWithStatusConfig"
+}
+resource "alicloud_slb" "slb" {
+  name = "testAccCheckAlicloudEipsDataSourceWithStatusConfig"
+  specification = "slb.s2.small"
+  vswitch_id = "${alicloud_vswitch.vswitch.id}"
+}
+resource "alicloud_eip_association" "eipAssociation" {
+  allocation_id = "${alicloud_eip.inUseEip.id}"
+  instance_id = "${alicloud_slb.slb.id}"
+}
+
+data "alicloud_eips" "availableEips" {
+  ids = ["${alicloud_eip.availableEip.*.id}"]
+  status = "Available"
+}
+data "alicloud_eips" "inUseEips" {
+  ids = ["${alicloud_eip_association.eipAssociation.allocation_id}"]
+  status = "InUse"
 }
 `

--- a/website/docs/d/eips.html.markdown
+++ b/website/docs/d/eips.html.markdown
@@ -14,6 +14,7 @@ This data source provides a list of EIPs (Elastic IP address) owned by an Alibab
 
 ```
 data "alicloud_eips" "eips_ds" {
+  status = "Available"
 }
 
 output "first_eip_id" {
@@ -27,7 +28,8 @@ The following arguments are supported:
 
 * `ids` - (Optional) A list of EIP IDs.
 * `ip_addresses` - (Optional) A list of EIP public IP addresses.
-* `in_use` - (Deprecated) Deprecated since the version 1.8.0 of this provider.
+* `in_use` - (Deprecated) Deprecated since the version 1.8.0 of this provider. Use `status` instead.
+* `status` - (Optional) EIP status. Valid values: `Associating`, `Unassociating`, `InUse` and `Available`. If undefined, all statuses are considered.
 * `output_file` - (Optional) File name where to save data source results (after running `terraform plan`).
 
 ## Attributes Reference


### PR DESCRIPTION
This modifications allows us to find available EIPs like this:
```
data "alicloud_eips" "abc" {
    status = "Available"
}
```