### PR TITLE
Get account id automatically

### DIFF
--- a/alicloud/common.go
+++ b/alicloud/common.go
@@ -143,13 +143,6 @@ func getRegionId(d *schema.ResourceData, meta interface{}) string {
 	return meta.(*AliyunClient).RegionId
 }
 
-func requireAccountId(meta interface{}) error {
-	if meta.(*AliyunClient).AccountId == "" {
-		return fmt.Errorf("Provider field 'account_id' is required for this resource.")
-	}
-	return nil
-}
-
 // Protocol represents network protocol
 type Protocol string
 

--- a/alicloud/resource_alicloud_fc_function.go
+++ b/alicloud/resource_alicloud_fc_function.go
@@ -101,11 +101,11 @@ func resourceAlicloudFCFunction() *schema.Resource {
 }
 
 func resourceAlicloudFCFunctionCreate(d *schema.ResourceData, meta interface{}) error {
-	if err := requireAccountId(meta); err != nil {
+	client := meta.(*AliyunClient)
+	conn, err := client.Fcconn()
+	if err != nil {
 		return err
 	}
-	client := meta.(*AliyunClient)
-	conn := client.fcconn
 
 	serviceName := d.Get("service").(string)
 	var name string
@@ -161,10 +161,6 @@ func resourceAlicloudFCFunctionCreate(d *schema.ResourceData, meta interface{}) 
 }
 
 func resourceAlicloudFCFunctionRead(d *schema.ResourceData, meta interface{}) error {
-	if err := requireAccountId(meta); err != nil {
-		return err
-	}
-
 	client := meta.(*AliyunClient)
 
 	split := strings.Split(d.Id(), COLON_SEPARATED)
@@ -194,10 +190,11 @@ func resourceAlicloudFCFunctionRead(d *schema.ResourceData, meta interface{}) er
 }
 
 func resourceAlicloudFCFunctionUpdate(d *schema.ResourceData, meta interface{}) error {
-	if err := requireAccountId(meta); err != nil {
+	client := meta.(*AliyunClient)
+	conn, err := client.Fcconn()
+	if err != nil {
 		return err
 	}
-	client := meta.(*AliyunClient)
 
 	d.Partial(true)
 	updateInput := &fc.UpdateFunctionInput{}
@@ -240,7 +237,7 @@ func resourceAlicloudFCFunctionUpdate(d *schema.ResourceData, meta interface{}) 
 		}
 		updateInput.Code = code
 
-		if _, err := client.fcconn.UpdateFunction(updateInput); err != nil {
+		if _, err := conn.UpdateFunction(updateInput); err != nil {
 			return fmt.Errorf("UpdateFunction %s got an error: %#v.", d.Id(), err)
 		}
 	}
@@ -250,14 +247,15 @@ func resourceAlicloudFCFunctionUpdate(d *schema.ResourceData, meta interface{}) 
 }
 
 func resourceAlicloudFCFunctionDelete(d *schema.ResourceData, meta interface{}) error {
-	if err := requireAccountId(meta); err != nil {
+	client := meta.(*AliyunClient)
+	conn, err := client.Fcconn()
+	if err != nil {
 		return err
 	}
-	client := meta.(*AliyunClient)
 	split := strings.Split(d.Id(), COLON_SEPARATED)
 
 	return resource.Retry(5*time.Minute, func() *resource.RetryError {
-		if _, err := client.fcconn.DeleteFunction(&fc.DeleteFunctionInput{
+		if _, err := conn.DeleteFunction(&fc.DeleteFunctionInput{
 			ServiceName:  StringPointer(split[0]),
 			FunctionName: StringPointer(split[1]),
 		}); err != nil {

--- a/alicloud/resource_alicloud_fc_service.go
+++ b/alicloud/resource_alicloud_fc_service.go
@@ -106,11 +106,11 @@ func resourceAlicloudFCService() *schema.Resource {
 }
 
 func resourceAlicloudFCServiceCreate(d *schema.ResourceData, meta interface{}) error {
-	if err := requireAccountId(meta); err != nil {
+	client := meta.(*AliyunClient)
+	conn, err := client.Fcconn()
+	if err != nil {
 		return err
 	}
-	client := meta.(*AliyunClient)
-	conn := client.fcconn
 
 	var name string
 	if v, ok := d.GetOk("name"); ok {
@@ -166,10 +166,6 @@ func resourceAlicloudFCServiceCreate(d *schema.ResourceData, meta interface{}) e
 }
 
 func resourceAlicloudFCServiceRead(d *schema.ResourceData, meta interface{}) error {
-	if err := requireAccountId(meta); err != nil {
-		return err
-	}
-
 	client := meta.(*AliyunClient)
 
 	service, err := client.DescribeFcService(d.Id())
@@ -212,10 +208,11 @@ func resourceAlicloudFCServiceRead(d *schema.ResourceData, meta interface{}) err
 }
 
 func resourceAlicloudFCServiceUpdate(d *schema.ResourceData, meta interface{}) error {
-	if err := requireAccountId(meta); err != nil {
+	client := meta.(*AliyunClient)
+	conn, err := client.Fcconn()
+	if err != nil {
 		return err
 	}
-	client := meta.(*AliyunClient)
 
 	d.Partial(true)
 	updateInput := &fc.UpdateServiceInput{}
@@ -253,7 +250,7 @@ func resourceAlicloudFCServiceUpdate(d *schema.ResourceData, meta interface{}) e
 
 	if updateInput != nil {
 		updateInput.ServiceName = StringPointer(d.Id())
-		if _, err := client.fcconn.UpdateService(updateInput); err != nil {
+		if _, err := conn.UpdateService(updateInput); err != nil {
 			return fmt.Errorf("UpdateService %s got an error: %#v.", d.Id(), err)
 		}
 	}
@@ -263,13 +260,14 @@ func resourceAlicloudFCServiceUpdate(d *schema.ResourceData, meta interface{}) e
 }
 
 func resourceAlicloudFCServiceDelete(d *schema.ResourceData, meta interface{}) error {
-	if err := requireAccountId(meta); err != nil {
+	client := meta.(*AliyunClient)
+	conn, err := client.Fcconn()
+	if err != nil {
 		return err
 	}
-	client := meta.(*AliyunClient)
 
 	return resource.Retry(5*time.Minute, func() *resource.RetryError {
-		if _, err := client.fcconn.DeleteService(&fc.DeleteServiceInput{
+		if _, err := conn.DeleteService(&fc.DeleteServiceInput{
 			ServiceName: StringPointer(d.Id()),
 		}); err != nil {
 			if IsExceptedErrors(err, []string{ServiceNotFound}) {

--- a/alicloud/resource_alicloud_router_interface_connection.go
+++ b/alicloud/resource_alicloud_router_interface_connection.go
@@ -109,7 +109,10 @@ func resourceAlicloudRouterInterfaceConnectionCreate(d *schema.ResourceData, met
 	} else {
 		owner := ri.OppositeInterfaceOwnerId
 		if owner == "" {
-			owner = client.AccountId
+			owner, err = client.AccountId()
+			if err != nil {
+				return err
+			}
 		}
 		if owner == "" {
 			return fmt.Errorf("Opposite router interface owner id is empty. Please use field 'opposite_interface_owner_id' or globle field 'account_id' to set.")

--- a/alicloud/service_alicloud_fc.go
+++ b/alicloud/service_alicloud_fc.go
@@ -7,7 +7,11 @@ import (
 )
 
 func (client *AliyunClient) DescribeFcService(name string) (service *fc.GetServiceOutput, err error) {
-	service, err = client.fcconn.GetService(&fc.GetServiceInput{
+	conn, err := client.Fcconn()
+	if err != nil {
+		return
+	}
+	service, err = conn.GetService(&fc.GetServiceInput{
 		ServiceName: &name,
 	})
 	if err != nil {
@@ -25,7 +29,12 @@ func (client *AliyunClient) DescribeFcService(name string) (service *fc.GetServi
 }
 
 func (client *AliyunClient) DescribeFcFunction(service, name string) (function *fc.GetFunctionOutput, err error) {
-	function, err = client.fcconn.GetFunction(&fc.GetFunctionInput{
+	conn, err := client.Fcconn()
+	if err != nil {
+		return
+	}
+
+	function, err = conn.GetFunction(&fc.GetFunctionInput{
 		ServiceName:  &service,
 		FunctionName: &name,
 	})
@@ -44,7 +53,12 @@ func (client *AliyunClient) DescribeFcFunction(service, name string) (function *
 }
 
 func (client *AliyunClient) DescribeFcTrigger(service, function, name string) (trigger *fc.GetTriggerOutput, err error) {
-	trigger, err = client.fcconn.GetTrigger(&fc.GetTriggerInput{
+	conn, err := client.Fcconn()
+	if err != nil {
+		return
+	}
+
+	trigger, err = conn.GetTrigger(&fc.GetTriggerInput{
 		ServiceName:  &service,
 		FunctionName: &function,
 		TriggerName:  &name,

--- a/alicloud/service_alicloud_sts.go
+++ b/alicloud/service_alicloud_sts.go
@@ -1,0 +1,23 @@
+package alicloud
+
+import (
+	"github.com/denverdino/aliyungo/sts"
+)
+
+func (client *AliyunClient) GetCallerIdentity() (*sts.GetCallerIdentityResponse, error) {
+	invoker := NewInvoker()
+	var identityResponse *sts.GetCallerIdentityResponse
+
+	err := invoker.Run(func() error {
+		identity, err := client.stsconn.GetCallerIdentity()
+		if err != nil {
+			return err
+		}
+		if identity == nil {
+			return GetNotFoundErrorFromString("Caller identity not found.")
+		}
+		identityResponse = identity
+		return nil
+	})
+	return identityResponse, err
+}

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -112,22 +112,22 @@ The following arguments are supported:
   it can also be sourced from the `ALICLOUD_REGION` environment variables.
 
 * `security_token` - Alicloud [Security Token Service](https://www.alibabacloud.com/help/doc-detail/66222.html).
-  It can be sourced from the `ALICLOUD_SECURITY_TOKEN`.
+  It can be sourced from the `ALICLOUD_SECURITY_TOKEN` environment variable.
 
-* `account_id` - (Optional) Alibaba Cloud Account ID. It is required by the Function Compute service and to connect router interfaces.
-  It can be sourced from the `ALICLOUD_ACCOUNT_ID`.
+* `account_id` - (Optional) Alibaba Cloud Account ID. It is used by the Function Compute service and to connect router interfaces.
+  If not provided, the provider will attempt to retrieve it automatically with [STS GetCallerIdentity](https://www.alibabacloud.com/help/doc-detail/43767.htm).
+  It can be sourced from the `ALICLOUD_ACCOUNT_ID` environment variable.
 
 Nested `endpoints` block supports the following:
 
 * `log_endpoint` - (Optional) The self-defined endpoint of log service, referring to [Service Endpoints](https://www.alibabacloud.com/help/doc-detail/29008.html).
-  It can be sourced from the `LOG_ENDPOINT`
+  It can be sourced from the `LOG_ENDPOINT` environment variable.
 
 * `fc` - (Optional) Use this to override the default endpoint
   URL constructed from the `region`. Referring to [Function Compute Service Endpoints](https://www.alibabacloud.com/help/doc-detail/52984.htm).
   It's typically used to connect to custom Function Compute service endpoints.
-  It can be sourced from the `FC_ENDPOINT`
+  It can be sourced from the `FC_ENDPOINT` environment variable.
 
 ## Testing
 
-Credentials must be provided via the `ALICLOUD_ACCESS_KEY`, `ALICLOUD_SECRET_KEY`, and `ALICLOUD_ACCOUNT_ID`
-environment variables in order to run acceptance tests.
+Credentials must be provided via the `ALICLOUD_ACCESS_KEY`, `ALICLOUD_SECRET_KEY` environment variables in order to run acceptance tests.


### PR DESCRIPTION
Since account_id can be obtained via STS GetCallerIdentity, this PR automatically retrieves this value if needed in case it has not been provided.