### PR TITLE
Base64 encode ESS scaling config user_data

### DIFF
--- a/alicloud/resource_alicloud_ess_scalingconfiguration.go
+++ b/alicloud/resource_alicloud_ess_scalingconfiguration.go
@@ -1,6 +1,7 @@
 package alicloud
 
 import (
+	"encoding/base64"
 	"fmt"
 	"strings"
 	"time"
@@ -481,7 +482,12 @@ func buildAlicloudEssScalingConfigurationArgs(d *schema.ResourceData, meta inter
 	}
 
 	if v, ok := d.GetOk("user_data"); ok && v.(string) != "" {
-		args.UserData = v.(string)
+		_, base64DecodeError := base64.StdEncoding.DecodeString(v.(string))
+		if base64DecodeError == nil {
+			args.UserData = v.(string)
+		} else {
+			args.UserData = base64.StdEncoding.EncodeToString([]byte(v.(string)))
+		}
 	}
 
 	if v, ok := d.GetOk("tags"); ok {

--- a/alicloud/resource_alicloud_ess_scalingconfiguration_test.go
+++ b/alicloud/resource_alicloud_ess_scalingconfiguration_test.go
@@ -38,6 +38,10 @@ func TestAccAlicloudEssScalingConfiguration_basic(t *testing.T) {
 						"alicloud_ess_scaling_configuration.foo",
 						"key_name",
 						"testAccEssScalingConfigurationConfig"),
+					resource.TestCheckResourceAttr(
+						"alicloud_ess_scaling_configuration.foo",
+						"user_data",
+						"#!/bin/bash\necho \"hello\"\n"),
 				),
 			},
 		},
@@ -258,6 +262,10 @@ resource "alicloud_ess_scaling_configuration" "foo" {
 	security_group_id = "${alicloud_security_group.tf_test_foo.id}"
 	key_name = "${alicloud_key_pair.key.id}"
 	force_delete = true
+	user_data = <<EOF
+#!/bin/bash
+echo "hello"
+EOF
 }
 
 resource "alicloud_key_pair" "key" {


### PR DESCRIPTION
This is to fix #596. `user_data` is first checked if it is already base64 encoded (this is to ensure backward-compatibility), if not, then its encoded.