### PR TITLE
Add flags to skip tests that use features not supported in all regions

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,15 +123,15 @@ TF_ACC=1 TF_LOG=INFO go test ./alicloud -v -run=TestAccAlicloud -timeout=1440m |
 go2xunit -input $outfile -output $GOPATH/tests.xml
 ```
 
--> **Note:** The last line is optional, it allows you to convert test results into a XML format compatible with xUnit.
+-> **Note:** The last line is optional, it allows to convert test results into a XML format compatible with xUnit.
 
 Because some features are not available in all regions, the following environment variables can be set in order to
 skip tests that use these features:
-* ALICLOUD_SKIP_TESTS_FOR_SLB_SPECIFICATION=true
-* ALICLOUD_SKIP_TESTS_FOR_SLB_PAY_BY_BANDWIDTH=true
-* ALICLOUD_SKIP_TESTS_FOR_FUNCTION_COMPUTE=true
-* ALICLOUD_SKIP_TESTS_FOR_PVTZ_ZONE=true
-* ALICLOUD_SKIP_TESTS_FOR_RDS_MULTIAZ=true
+* ALICLOUD_SKIP_TESTS_FOR_SLB_SPECIFICATION=true    - Server Load Balancer with guaranteed performance specifications (old implementation has only shared performance)
+* ALICLOUD_SKIP_TESTS_FOR_SLB_PAY_BY_BANDWIDTH=true - Server Load Balancer with a "pay by bandwidth" billing method (mostly available in China)
+* ALICLOUD_SKIP_TESTS_FOR_FUNCTION_COMPUTE=true     - Function Compute
+* ALICLOUD_SKIP_TESTS_FOR_PVTZ_ZONE=true            - Private Zone
+* ALICLOUD_SKIP_TESTS_FOR_RDS_MULTIAZ=true          - Apsara RDS with multiple availability zones
 
 #### Common problems
 

--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ go2xunit -input $outfile -output $GOPATH/tests.xml
 Because some features are not available in all regions, the following environment variables can be set in order to
 skip tests that use these features:
 * ALICLOUD_SKIP_TESTS_FOR_SLB_SPECIFICATION=true
+* ALICLOUD_SKIP_TESTS_FOR_SLB_PAY_BY_BANDWIDTH=true
 * ALICLOUD_SKIP_TESTS_FOR_FUNCTION_COMPUTE=true
 * ALICLOUD_SKIP_TESTS_FOR_PVTZ_ZONE=true
 * ALICLOUD_SKIP_TESTS_FOR_RDS_MULTIAZ=true

--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ skip tests that use these features:
 * ALICLOUD_SKIP_TESTS_FOR_FUNCTION_COMPUTE=true     - Function Compute
 * ALICLOUD_SKIP_TESTS_FOR_PVTZ_ZONE=true            - Private Zone
 * ALICLOUD_SKIP_TESTS_FOR_RDS_MULTIAZ=true          - Apsara RDS with multiple availability zones
+* ALICLOUD_SKIP_TESTS_FOR_CLASSIC_NETWORK=true      - Classic network configuration
 
 #### Common problems
 

--- a/README.md
+++ b/README.md
@@ -109,6 +109,29 @@ The most recent documentation is available here:
 * [Terraform Docs](https://www.terraform.io/docs/providers/alicloud/index.html)
 * [Github](https://github.com/alibaba/terraform-provider-docs)
 
+#### Acceptance Testing
+Before making a release, the resources and data sources are tested automatically with acceptance tests (the tests are located in the alicloud/*_test.go files).
+You can run them by entering the following instructions in a terminal:
+```
+cd $GOPATH/src/github.com/alibaba/terraform-provider
+export ALICLOUD_ACCESS_KEY=xxx
+export ALICLOUD_SECRET_KEY=xxx
+export ALICLOUD_REGION=xxx
+export ALICLOUD_ACCOUNT_ID=xxx
+export outfile=gotest.out
+TF_ACC=1 TF_LOG=INFO go test ./alicloud -v -run=TestAccAlicloud -timeout=1440m | tee $outfile
+go2xunit -input $outfile -output $GOPATH/tests.xml
+```
+
+-> **Note:** The last line is optional, it allows you to convert test results into a XML format compatible with xUnit.
+
+Because some features are not available in all regions, the following environment variables can be set in order to
+skip tests that use these features:
+* ALICLOUD_SKIP_TESTS_FOR_SLB_SPECIFICATION=true
+* ALICLOUD_SKIP_TESTS_FOR_FUNCTION_COMPUTE=true
+* ALICLOUD_SKIP_TESTS_FOR_PVTZ_ZONE=true
+* ALICLOUD_SKIP_TESTS_FOR_RDS_MULTIAZ=true
+
 #### Common problems
 
 1.

--- a/alicloud/data_source_alicloud_pvtz_zone_records_test.go
+++ b/alicloud/data_source_alicloud_pvtz_zone_records_test.go
@@ -8,6 +8,11 @@ import (
 )
 
 func TestAccAlicloudPvtzZoneRecordsDataSource_basic(t *testing.T) {
+	if !isRegionSupports(PrivateZone) {
+		logTestSkippedBecauseOfUnsupportedRegionalFeatures(t.Name(), PrivateZone)
+		return
+	}
+
 	var pvtzZoneRecord pvtz.Record
 
 	resource.Test(t, resource.TestCase{

--- a/alicloud/data_source_alicloud_pvtz_zones_test.go
+++ b/alicloud/data_source_alicloud_pvtz_zones_test.go
@@ -8,6 +8,11 @@ import (
 )
 
 func TestAccAlicloudPvtzZonesDataSource_basic(t *testing.T) {
+	if !isRegionSupports(PrivateZone) {
+		logTestSkippedBecauseOfUnsupportedRegionalFeatures(t.Name(), PrivateZone)
+		return
+	}
+
 	var pvtzZone pvtz.DescribeZoneInfoResponse
 
 	resource.Test(t, resource.TestCase{

--- a/alicloud/import_alicloud_fc_function_test.go
+++ b/alicloud/import_alicloud_fc_function_test.go
@@ -7,6 +7,11 @@ import (
 )
 
 func TestAccAlicloudFCFunction_import(t *testing.T) {
+	if !isRegionSupports(FunctionCompute) {
+		logTestSkippedBecauseOfUnsupportedRegionalFeatures(t.Name(), FunctionCompute)
+		return
+	}
+
 	resourceName := "alicloud_fc_function.foo"
 
 	resource.Test(t, resource.TestCase{

--- a/alicloud/import_alicloud_fc_service_test.go
+++ b/alicloud/import_alicloud_fc_service_test.go
@@ -7,6 +7,11 @@ import (
 )
 
 func TestAccAlicloudFCService_import(t *testing.T) {
+	if !isRegionSupports(FunctionCompute) {
+		logTestSkippedBecauseOfUnsupportedRegionalFeatures(t.Name(), FunctionCompute)
+		return
+	}
+
 	resourceName := "alicloud_fc_service.foo"
 
 	resource.Test(t, resource.TestCase{

--- a/alicloud/import_alicloud_fc_trigger_test.go
+++ b/alicloud/import_alicloud_fc_trigger_test.go
@@ -8,6 +8,11 @@ import (
 
 // Import function does not support read account_id from provider.
 func SkipTestAccAlicloudFCTrigger_import(t *testing.T) {
+	if !isRegionSupports(FunctionCompute) {
+		logTestSkippedBecauseOfUnsupportedRegionalFeatures(t.Name(), FunctionCompute)
+		return
+	}
+
 	resourceName := "alicloud_fc_trigger.foo"
 
 	resource.Test(t, resource.TestCase{

--- a/alicloud/import_alicloud_pvtz_zone_attachment_test.go
+++ b/alicloud/import_alicloud_pvtz_zone_attachment_test.go
@@ -7,6 +7,11 @@ import (
 )
 
 func TestAccAlicloudPvtzZoneAttachment_importBasic(t *testing.T) {
+	if !isRegionSupports(PrivateZone) {
+		logTestSkippedBecauseOfUnsupportedRegionalFeatures(t.Name(), PrivateZone)
+		return
+	}
+
 	resourceName := "alicloud_pvtz_zone_attachment.zone-attachment"
 
 	resource.Test(t, resource.TestCase{

--- a/alicloud/import_alicloud_pvtz_zone_record_test.go
+++ b/alicloud/import_alicloud_pvtz_zone_record_test.go
@@ -7,6 +7,11 @@ import (
 )
 
 func TestAccAlicloudPvtzZoneRecord_importBasic(t *testing.T) {
+	if !isRegionSupports(PrivateZone) {
+		logTestSkippedBecauseOfUnsupportedRegionalFeatures(t.Name(), PrivateZone)
+		return
+	}
+
 	resourceName := "alicloud_pvtz_zone_record.foo"
 
 	resource.Test(t, resource.TestCase{

--- a/alicloud/import_alicloud_pvtz_zone_test.go
+++ b/alicloud/import_alicloud_pvtz_zone_test.go
@@ -7,6 +7,11 @@ import (
 )
 
 func TestAccAlicloudPvtzZone_importBasic(t *testing.T) {
+	if !isRegionSupports(PrivateZone) {
+		logTestSkippedBecauseOfUnsupportedRegionalFeatures(t.Name(), PrivateZone)
+		return
+	}
+
 	resourceName := "alicloud_pvtz_zone.foo"
 
 	resource.Test(t, resource.TestCase{

--- a/alicloud/resource_alicloud_db_instance_test.go
+++ b/alicloud/resource_alicloud_db_instance_test.go
@@ -92,6 +92,11 @@ func TestAccAlicloudDBInstance_vpc(t *testing.T) {
 }
 
 func TestAccAlicloudDBInstance_multiAZ(t *testing.T) {
+	if !isRegionSupports(RdsMultiAZ) {
+		logTestSkippedBecauseOfUnsupportedRegionalFeatures(t.Name(), RdsMultiAZ)
+		return
+	}
+
 	var instance rds.DBInstanceAttribute
 
 	resource.Test(t, resource.TestCase{
@@ -332,10 +337,6 @@ resource "alicloud_db_instance" "foo" {
 }
 `
 const testAccDBInstance_multiAZ = `
-provider "alicloud" {
-  region = "cn-shanghai"
-}
-
 data "alicloud_zones" "default" {
   available_resource_creation= "Rds"
   multi = true

--- a/alicloud/resource_alicloud_fc_function_test.go
+++ b/alicloud/resource_alicloud_fc_function_test.go
@@ -13,6 +13,11 @@ import (
 )
 
 func TestAccAlicloudFCFunction_basic(t *testing.T) {
+	if !isRegionSupports(FunctionCompute) {
+		logTestSkippedBecauseOfUnsupportedRegionalFeatures(t.Name(), FunctionCompute)
+		return
+	}
+
 	var service fc.GetServiceOutput
 	var function fc.GetFunctionOutput
 	var bucket oss.BucketInfo

--- a/alicloud/resource_alicloud_fc_service_test.go
+++ b/alicloud/resource_alicloud_fc_service_test.go
@@ -14,6 +14,11 @@ import (
 )
 
 func TestAccAlicloudFCService_basic(t *testing.T) {
+	if !isRegionSupports(FunctionCompute) {
+		logTestSkippedBecauseOfUnsupportedRegionalFeatures(t.Name(), FunctionCompute)
+		return
+	}
+
 	var service fc.GetServiceOutput
 	var project sls.LogProject
 	var store sls.LogStore
@@ -38,6 +43,11 @@ func TestAccAlicloudFCService_basic(t *testing.T) {
 }
 
 func TestAccAlicloudFCService_update(t *testing.T) {
+	if !isRegionSupports(FunctionCompute) {
+		logTestSkippedBecauseOfUnsupportedRegionalFeatures(t.Name(), FunctionCompute)
+		return
+	}
+
 	var service fc.GetServiceOutput
 	var vpcInstance vpc.DescribeVpcAttributeResponse
 	var group ecs.DescribeSecurityGroupAttributeResponse

--- a/alicloud/resource_alicloud_fc_trigger_test.go
+++ b/alicloud/resource_alicloud_fc_trigger_test.go
@@ -13,6 +13,11 @@ import (
 )
 
 func TestAccAlicloudFCTrigger_log(t *testing.T) {
+	if !isRegionSupports(FunctionCompute) {
+		logTestSkippedBecauseOfUnsupportedRegionalFeatures(t.Name(), FunctionCompute)
+		return
+	}
+
 	var service fc.GetServiceOutput
 	var project sls.LogProject
 	var store sls.LogStore

--- a/alicloud/resource_alicloud_instance_test.go
+++ b/alicloud/resource_alicloud_instance_test.go
@@ -12,6 +12,11 @@ import (
 )
 
 func TestAccAlicloudInstance_basic(t *testing.T) {
+	if !isRegionSupports(ClassicNetwork) {
+		logTestSkippedBecauseOfUnsupportedRegionalFeatures(t.Name(), ClassicNetwork)
+		return
+	}
+
 	var instance ecs.Instance
 
 	testCheck := func(*terraform.State) error {

--- a/alicloud/resource_alicloud_pvtz_zone_attachment_test.go
+++ b/alicloud/resource_alicloud_pvtz_zone_attachment_test.go
@@ -11,6 +11,11 @@ import (
 )
 
 func TestAccAlicloudPvtzZoneAttachment_Basic(t *testing.T) {
+	if !isRegionSupports(PrivateZone) {
+		logTestSkippedBecauseOfUnsupportedRegionalFeatures(t.Name(), PrivateZone)
+		return
+	}
+
 	var zone pvtz.DescribeZoneInfoResponse
 	var vpc vpc.DescribeVpcAttributeResponse
 	resource.Test(t, resource.TestCase{
@@ -35,6 +40,11 @@ func TestAccAlicloudPvtzZoneAttachment_Basic(t *testing.T) {
 }
 
 func TestAccAlicloudPvtzZoneAttachment_update(t *testing.T) {
+	if !isRegionSupports(PrivateZone) {
+		logTestSkippedBecauseOfUnsupportedRegionalFeatures(t.Name(), PrivateZone)
+		return
+	}
+
 	var zone pvtz.DescribeZoneInfoResponse
 	var vpc vpc.DescribeVpcAttributeResponse
 
@@ -67,6 +77,11 @@ func TestAccAlicloudPvtzZoneAttachment_update(t *testing.T) {
 }
 
 func TestAccAlicloudPvtzZoneAttachment_multi(t *testing.T) {
+	if !isRegionSupports(PrivateZone) {
+		logTestSkippedBecauseOfUnsupportedRegionalFeatures(t.Name(), PrivateZone)
+		return
+	}
+
 	var zone pvtz.DescribeZoneInfoResponse
 	var vpc vpc.DescribeVpcAttributeResponse
 

--- a/alicloud/resource_alicloud_pvtz_zone_record_test.go
+++ b/alicloud/resource_alicloud_pvtz_zone_record_test.go
@@ -11,6 +11,11 @@ import (
 )
 
 func TestAccAlicloudPvtzZoneRecord_Basic(t *testing.T) {
+	if !isRegionSupports(PrivateZone) {
+		logTestSkippedBecauseOfUnsupportedRegionalFeatures(t.Name(), PrivateZone)
+		return
+	}
+
 	var record pvtz.Record
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
@@ -34,6 +39,11 @@ func TestAccAlicloudPvtzZoneRecord_Basic(t *testing.T) {
 }
 
 func TestAccAlicloudPvtzZoneRecord_update(t *testing.T) {
+	if !isRegionSupports(PrivateZone) {
+		logTestSkippedBecauseOfUnsupportedRegionalFeatures(t.Name(), PrivateZone)
+		return
+	}
+
 	var record pvtz.Record
 
 	resource.Test(t, resource.TestCase{
@@ -65,6 +75,11 @@ func TestAccAlicloudPvtzZoneRecord_update(t *testing.T) {
 }
 
 func TestAccAlicloudPvtzZoneRecord_multi(t *testing.T) {
+	if !isRegionSupports(PrivateZone) {
+		logTestSkippedBecauseOfUnsupportedRegionalFeatures(t.Name(), PrivateZone)
+		return
+	}
+
 	var record pvtz.Record
 
 	resource.Test(t, resource.TestCase{

--- a/alicloud/resource_alicloud_pvtz_zone_test.go
+++ b/alicloud/resource_alicloud_pvtz_zone_test.go
@@ -10,6 +10,11 @@ import (
 )
 
 func TestAccAlicloudPvtzZone_Basic(t *testing.T) {
+	if !isRegionSupports(PrivateZone) {
+		logTestSkippedBecauseOfUnsupportedRegionalFeatures(t.Name(), PrivateZone)
+		return
+	}
+
 	var zone pvtz.DescribeZoneInfoResponse
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
@@ -33,6 +38,11 @@ func TestAccAlicloudPvtzZone_Basic(t *testing.T) {
 }
 
 func TestAccAlicloudPvtzZone_update(t *testing.T) {
+	if !isRegionSupports(PrivateZone) {
+		logTestSkippedBecauseOfUnsupportedRegionalFeatures(t.Name(), PrivateZone)
+		return
+	}
+
 	var zone pvtz.DescribeZoneInfoResponse
 
 	resource.Test(t, resource.TestCase{
@@ -64,6 +74,11 @@ func TestAccAlicloudPvtzZone_update(t *testing.T) {
 }
 
 func TestAccAlicloudPvtzZone_multi(t *testing.T) {
+	if !isRegionSupports(PrivateZone) {
+		logTestSkippedBecauseOfUnsupportedRegionalFeatures(t.Name(), PrivateZone)
+		return
+	}
+
 	var zone pvtz.DescribeZoneInfoResponse
 
 	resource.Test(t, resource.TestCase{

--- a/alicloud/resource_alicloud_slb_test.go
+++ b/alicloud/resource_alicloud_slb_test.go
@@ -12,6 +12,11 @@ import (
 
 //test internet_charge_type is PayByBandwidth and it only support China mainland region
 func TestAccAlicloudSlb_paybybandwidth(t *testing.T) {
+	if !isRegionSupports(SlbPayByBandwidth) {
+		logTestSkippedBecauseOfUnsupportedRegionalFeatures(t.Name(), SlbPayByBandwidth)
+		return
+	}
+
 	var slb slb.DescribeLoadBalancerAttributeResponse
 
 	resource.Test(t, resource.TestCase{
@@ -64,6 +69,11 @@ func TestAccAlicloudSlb_vpc(t *testing.T) {
 }
 
 func TestAccAlicloudSlb_spec(t *testing.T) {
+	if !isRegionSupports(SlbSpecification) {
+		logTestSkippedBecauseOfUnsupportedRegionalFeatures(t.Name(), SlbSpecification)
+		return
+	}
+
 	var slb slb.DescribeLoadBalancerAttributeResponse
 
 	resource.Test(t, resource.TestCase{
@@ -142,10 +152,6 @@ func testAccCheckSlbDestroy(s *terraform.State) error {
 }
 
 const testAccSlbPayByBandwidth = `
-provider "alicloud" {
-	region = "cn-hangzhou"
-}
-
 resource "alicloud_slb" "bandwidth" {
   name = "tf_test_slb_paybybandwidth"
   specification = "slb.s2.medium"
@@ -177,9 +183,6 @@ resource "alicloud_slb" "vpc" {
 }
 `
 const testAccSlbBandSpec = `
-provider "alicloud" {
-	region = "cn-hangzhou"
-}
 data "alicloud_zones" "default" {
 	"available_resource_creation"= "VSwitch"
 }
@@ -203,9 +206,6 @@ resource "alicloud_slb" "spec" {
 `
 
 const testAccSlbBandSpecUpdate = `
-provider "alicloud" {
-	region = "cn-hangzhou"
-}
 data "alicloud_zones" "default" {
 	"available_resource_creation"= "VSwitch"
 }

--- a/alicloud/testing.go
+++ b/alicloud/testing.go
@@ -8,10 +8,11 @@ import (
 type RegionalFeature string
 
 const (
-	SlbSpecification = RegionalFeature("SLB_SPECIFICATION")
-	FunctionCompute  = RegionalFeature("FUNCTION_COMPUTE")
-	PrivateZone      = RegionalFeature("PRIVATE_ZONE")
-	RdsMultiAZ       = RegionalFeature("RDS_MULTI_AZ")
+	SlbSpecification  = RegionalFeature("SLB_SPECIFICATION")
+	SlbPayByBandwidth = RegionalFeature("SLB_PAY_BY_BANDWIDTH")
+	FunctionCompute   = RegionalFeature("FUNCTION_COMPUTE")
+	PrivateZone       = RegionalFeature("PRIVATE_ZONE")
+	RdsMultiAZ        = RegionalFeature("RDS_MULTI_AZ")
 )
 
 func isRegionSupports(features ...RegionalFeature) bool {

--- a/alicloud/testing.go
+++ b/alicloud/testing.go
@@ -1,0 +1,29 @@
+package alicloud
+
+import (
+	"os"
+	"log"
+)
+
+type RegionalFeature string
+
+const (
+	SlbSpecification = RegionalFeature("SLB_SPECIFICATION")
+	FunctionCompute  = RegionalFeature("FUNCTION_COMPUTE")
+	PrivateZone      = RegionalFeature("PRIVATE_ZONE")
+	RdsMultiAZ       = RegionalFeature("RDS_MULTI_AZ")
+)
+
+func isRegionSupports(features ...RegionalFeature) bool {
+	for _, feature := range features {
+		featureSkipped := os.Getenv("ALICLOUD_SKIP_TESTS_FOR_"+string(feature)) == "true"
+		if featureSkipped {
+			return false
+		}
+	}
+	return true
+}
+
+func logTestSkippedBecauseOfUnsupportedRegionalFeatures(testName string, features ...RegionalFeature) {
+	log.Printf("[INFO] Test '%v' skipped because the current region doesn't support all the following features: %v\n", testName, features)
+}

--- a/alicloud/testing.go
+++ b/alicloud/testing.go
@@ -13,6 +13,7 @@ const (
 	FunctionCompute   = RegionalFeature("FUNCTION_COMPUTE")
 	PrivateZone       = RegionalFeature("PRIVATE_ZONE")
 	RdsMultiAZ        = RegionalFeature("RDS_MULTI_AZ")
+	ClassicNetwork    = RegionalFeature("CLASSIC_NETWORK")
 )
 
 func isRegionSupports(features ...RegionalFeature) bool {


### PR DESCRIPTION
This PR is especially useful when we need to test "Terraform alicloud provider + cloud products" in regions where not all features are supported. New environment variables can be added in order to skip tests that cannot run in the current region.