### PR TITLE
Fix the test TestAccAlicloudDnsDomainsDataSource_ali_domain because i…

### DIFF
--- a/alicloud/data_source_alicloud_dns_domains_test.go
+++ b/alicloud/data_source_alicloud_dns_domains_test.go
@@ -44,12 +44,18 @@ func TestAccAlicloudDnsDomainsDataSource_name_regex(t *testing.T) {
 }
 
 const testAccCheckAlicloudDomainsDataSourceAliDomainConfig = `
+resource "alicloud_dns_group" "group" {
+  name = "yufishgroup"
+}
+
 resource "alicloud_dns" "dns" {
   name = "yufish.com"
+  group_id = "${alicloud_dns_group.group.id}"
 }
 
 data "alicloud_dns_domains" "domain" {
   ali_domain = "${alicloud_dns.dns.name == "" ? false : false}"
+  group_name_regex = "${alicloud_dns_group.group.name}"
 }`
 
 const testAccCheckAlicloudDomainsDataSourceNameRegexConfig = `


### PR DESCRIPTION
…t could fail when existing domains also had ali_domain = false.

The test failed at the following line:
```
resource.TestCheckResourceAttr("data.alicloud_dns_domains.domain", "domains.#", "1"),
```
Because I had other existing domains.