### PR TITLE
Fix a bug with scaling-configuration always being force updated.

### DIFF
--- a/alicloud/resource_alicloud_ess_scalingconfiguration.go
+++ b/alicloud/resource_alicloud_ess_scalingconfiguration.go
@@ -1,6 +1,7 @@
 package alicloud
 
 import (
+	"encoding/base64"
 	"fmt"
 	"strings"
 	"time"
@@ -353,7 +354,7 @@ func resourceAliyunEssScalingConfigurationRead(d *schema.ResourceData, meta inte
 	d.Set("data_disk", flattenDataDiskMappings(c.DataDisks.DataDisk))
 	d.Set("role_name", c.RamRoleName)
 	d.Set("key_name", c.KeyPairName)
-	d.Set("user_data", userDataHashSum(c.UserData))
+	d.Set("user_data", base64.StdEncoding.EncodeToString([]byte(userDataHashSum(c.UserData))))
 	d.Set("force_delete", d.Get("force_delete").(bool))
 	d.Set("tags", essTagsToMap(c.Tags.Tag))
 	d.Set("instance_name", c.InstanceName)


### PR DESCRIPTION
ESS ScalingConfiguration requires the userdata to be base64 encoded when provided.
On an update, it reads the userdata as a raw string, and compares it with the base64 encoded data.
It will always force an update of the scaling configuration, even if nothing has changed.