### PR TITLE
New datasource alicloud_slbs.

### DIFF
--- a/alicloud/data_source_alicloud_slbs.go
+++ b/alicloud/data_source_alicloud_slbs.go
@@ -1,0 +1,244 @@
+package alicloud
+
+import (
+	"fmt"
+	"log"
+	"regexp"
+	"strings"
+
+	"github.com/aliyun/alibaba-cloud-sdk-go/sdk/requests"
+	"github.com/aliyun/alibaba-cloud-sdk-go/services/slb"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func dataSourceAlicloudSlbs() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAlicloudSlbsRead,
+
+		Schema: map[string]*schema.Schema{
+			"ids": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				ForceNew: true,
+				MinItems: 1,
+			},
+			"name_regex": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validateNameRegex,
+				ForceNew:     true,
+			},
+			"master_availability_zone": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"slave_availability_zone": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"network_type": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"vpc_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"vswitch_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"address": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+
+			// Computed values
+			"slbs": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"region_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"master_availability_zone": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"slave_availability_zone": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"status": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"network_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"vpc_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"vswitch_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"address": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"internet": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"creation_time": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceAlicloudSlbsRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AliyunClient).slbconn
+
+	args := slb.CreateDescribeLoadBalancersRequest()
+
+	if v, ok := d.GetOk("master_availability_zone"); ok && v.(string) != "" {
+		args.MasterZoneId = v.(string)
+	}
+	if v, ok := d.GetOk("slave_availability_zone"); ok && v.(string) != "" {
+		args.SlaveZoneId = v.(string)
+	}
+	if v, ok := d.GetOk("network_type"); ok && v.(string) != "" {
+		args.NetworkType = v.(string)
+	}
+	if v, ok := d.GetOk("vpc_id"); ok && v.(string) != "" {
+		args.VpcId = v.(string)
+	}
+	if v, ok := d.GetOk("vswitch_id"); ok && v.(string) != "" {
+		args.VSwitchId = v.(string)
+	}
+	if v, ok := d.GetOk("address"); ok && v.(string) != "" {
+		args.Address = v.(string)
+	}
+
+	idsMap := make(map[string]string)
+	if v, ok := d.GetOk("ids"); ok {
+		for _, vv := range v.([]interface{}) {
+			idsMap[Trim(vv.(string))] = Trim(vv.(string))
+		}
+	}
+
+	var allLoadBalancers []slb.LoadBalancer
+	args.PageSize = requests.NewInteger(PageSizeLarge)
+	args.PageNumber = requests.NewInteger(1)
+	for {
+		resp, err := conn.DescribeLoadBalancers(args)
+		if err != nil {
+			return err
+		}
+
+		if resp == nil || len(resp.LoadBalancers.LoadBalancer) < 1 {
+			break
+		}
+
+		allLoadBalancers = append(allLoadBalancers, resp.LoadBalancers.LoadBalancer...)
+
+		if len(resp.LoadBalancers.LoadBalancer) < PageSizeLarge {
+			break
+		}
+
+		args.PageNumber = args.PageNumber + requests.NewInteger(1)
+	}
+
+	var filteredLoadBalancersTemp []slb.LoadBalancer
+
+	nameRegex, ok := d.GetOk("name_regex")
+	if (ok && nameRegex.(string) != "") || (len(idsMap) > 0) {
+		var r *regexp.Regexp
+		if nameRegex != "" {
+			r = regexp.MustCompile(nameRegex.(string))
+		}
+		for _, balancer := range allLoadBalancers {
+			if r != nil && !r.MatchString(balancer.LoadBalancerName) {
+				continue
+			}
+			if len(idsMap) > 0 {
+				if _, ok := idsMap[balancer.LoadBalancerId]; !ok {
+					continue
+				}
+			}
+
+			filteredLoadBalancersTemp = append(filteredLoadBalancersTemp, balancer)
+		}
+	} else {
+		filteredLoadBalancersTemp = allLoadBalancers
+	}
+
+	if len(filteredLoadBalancersTemp) < 1 {
+		return fmt.Errorf("Your query returned no results. Please change your search criteria and try again.")
+	}
+
+	log.Printf("[DEBUG] alicloud_slbs - Slbs found: %#v", filteredLoadBalancersTemp)
+
+	return slbsDescriptionAttributes(d, filteredLoadBalancersTemp)
+}
+
+func slbsDescriptionAttributes(d *schema.ResourceData, loadBalancers []slb.LoadBalancer) error {
+	var ids []string
+	var s []map[string]interface{}
+	for _, loadBalancer := range loadBalancers {
+		mapping := map[string]interface{}{
+			"id":                       loadBalancer.LoadBalancerId,
+			"region_id":                loadBalancer.RegionId,
+			"master_availability_zone": loadBalancer.MasterZoneId,
+			"slave_availability_zone":  loadBalancer.SlaveZoneId,
+			"status":                   loadBalancer.LoadBalancerStatus,
+			"name":                     loadBalancer.LoadBalancerName,
+			"network_type":             loadBalancer.NetworkType,
+			"vpc_id":                   loadBalancer.VpcId,
+			"vswitch_id":               loadBalancer.VSwitchId,
+			"address":                  loadBalancer.Address,
+			"internet":                 loadBalancer.AddressType == strings.ToLower(string(Internet)),
+			"creation_time":            loadBalancer.CreateTime,
+		}
+
+		log.Printf("[DEBUG] alicloud_slbs - adding slb mapping: %v", mapping)
+		ids = append(ids, loadBalancer.LoadBalancerId)
+		s = append(s, mapping)
+	}
+
+	d.SetId(dataResourceIdHash(ids))
+	if err := d.Set("slbs", s); err != nil {
+		return err
+	}
+
+	// create a json file in current directory and write data source to it.
+	if output, ok := d.GetOk("output_file"); ok && output.(string) != "" {
+		writeToFile(output.(string), s)
+	}
+	return nil
+}

--- a/alicloud/data_source_alicloud_slbs_test.go
+++ b/alicloud/data_source_alicloud_slbs_test.go
@@ -1,0 +1,164 @@
+package alicloud
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccAlicloudSlbsDataSource_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckAlicloudSlbsDataSourceBasic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAlicloudDataSourceID("data.alicloud_slbs.balancers"),
+					resource.TestCheckResourceAttr("data.alicloud_slbs.balancers", "slbs.#", "1"),
+					resource.TestCheckResourceAttrSet("data.alicloud_slbs.balancers", "slbs.0.id"),
+					resource.TestCheckResourceAttrSet("data.alicloud_slbs.balancers", "slbs.0.region_id"),
+					resource.TestCheckResourceAttrSet("data.alicloud_slbs.balancers", "slbs.0.master_availability_zone"),
+					resource.TestCheckResourceAttrSet("data.alicloud_slbs.balancers", "slbs.0.slave_availability_zone"),
+					resource.TestCheckResourceAttr("data.alicloud_slbs.balancers", "slbs.0.status", "active"),
+					resource.TestCheckResourceAttr("data.alicloud_slbs.balancers", "slbs.0.name", "testAccCheckAlicloudSlbsDataSourceBasic"),
+					resource.TestCheckResourceAttr("data.alicloud_slbs.balancers", "slbs.0.network_type", "vpc"),
+					resource.TestCheckResourceAttrSet("data.alicloud_slbs.balancers", "slbs.0.vpc_id"),
+					resource.TestCheckResourceAttrSet("data.alicloud_slbs.balancers", "slbs.0.vswitch_id"),
+					resource.TestCheckResourceAttrSet("data.alicloud_slbs.balancers", "slbs.0.address"),
+					resource.TestCheckResourceAttr("data.alicloud_slbs.balancers", "slbs.0.internet", "false"),
+					resource.TestCheckResourceAttrSet("data.alicloud_slbs.balancers", "slbs.0.creation_time"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAlicloudSlbsDataSource_filterByIds(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckAlicloudSlbsDataSourceFilterByIds,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAlicloudDataSourceID("data.alicloud_slbs.balancers"),
+					resource.TestCheckResourceAttr("data.alicloud_slbs.balancers", "slbs.#", "1"),
+					resource.TestCheckResourceAttr("data.alicloud_slbs.balancers", "slbs.0.name", "testAccCheckAlicloudSlbsDataSourceFilterByIds"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAlicloudSlbsDataSource_filterByAllFields(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckAlicloudSlbsDataSourceFilterByAllFields,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAlicloudDataSourceID("data.alicloud_slbs.balancers"),
+					resource.TestCheckResourceAttr("data.alicloud_slbs.balancers", "slbs.#", "1"),
+					resource.TestCheckResourceAttr("data.alicloud_slbs.balancers", "slbs.0.name", "testAccCheckAlicloudSlbsDataSourceFilterByAllFields"),
+				),
+			},
+		},
+	})
+}
+
+const testAccCheckAlicloudSlbsDataSourceBasic = `
+variable "name" {
+	default = "testAccCheckAlicloudSlbsDataSourceBasic"
+}
+
+data "alicloud_zones" "az" {
+	"available_resource_creation"= "VSwitch"
+}
+
+resource "alicloud_vpc" "sample_vpc" {
+  name = "${var.name}"
+  cidr_block = "172.16.0.0/12"
+}
+
+resource "alicloud_vswitch" "sample_vswitch" {
+  vpc_id = "${alicloud_vpc.sample_vpc.id}"
+  cidr_block = "172.16.0.0/16"
+  availability_zone = "${data.alicloud_zones.az.zones.0.id}"
+}
+
+resource "alicloud_slb" "sample_slb" {
+  name = "${var.name}"
+  vswitch_id = "${alicloud_vswitch.sample_vswitch.id}"
+}
+
+data "alicloud_slbs" "balancers" {
+  name_regex = "${alicloud_slb.sample_slb.name}"
+}
+`
+
+const testAccCheckAlicloudSlbsDataSourceFilterByIds = `
+variable "name" {
+	default = "testAccCheckAlicloudSlbsDataSourceFilterByIds"
+}
+
+data "alicloud_zones" "az" {
+	"available_resource_creation"= "VSwitch"
+}
+
+resource "alicloud_vpc" "sample_vpc" {
+  name = "${var.name}"
+  cidr_block = "172.16.0.0/12"
+}
+
+resource "alicloud_vswitch" "sample_vswitch" {
+  vpc_id = "${alicloud_vpc.sample_vpc.id}"
+  cidr_block = "172.16.0.0/16"
+  availability_zone = "${data.alicloud_zones.az.zones.0.id}"
+}
+
+resource "alicloud_slb" "sample_slb" {
+  name = "${var.name}"
+  vswitch_id = "${alicloud_vswitch.sample_vswitch.id}"
+}
+
+data "alicloud_slbs" "balancers" {
+  ids = ["${alicloud_slb.sample_slb.id}"]
+}
+`
+
+const testAccCheckAlicloudSlbsDataSourceFilterByAllFields = `
+variable "name" {
+	default = "testAccCheckAlicloudSlbsDataSourceFilterByAllFields"
+}
+
+data "alicloud_zones" "az" {
+	"available_resource_creation"= "VSwitch"
+}
+
+resource "alicloud_vpc" "sample_vpc" {
+  name = "${var.name}"
+  cidr_block = "172.16.0.0/12"
+}
+
+resource "alicloud_vswitch" "sample_vswitch" {
+  vpc_id = "${alicloud_vpc.sample_vpc.id}"
+  cidr_block = "172.16.0.0/16"
+  availability_zone = "${data.alicloud_zones.az.zones.0.id}"
+}
+
+resource "alicloud_slb" "sample_slb" {
+  name = "${var.name}"
+  vswitch_id = "${alicloud_vswitch.sample_vswitch.id}"
+}
+
+data "alicloud_slbs" "balancers" {
+  ids = ["${alicloud_slb.sample_slb.id}"]
+  name_regex = "${alicloud_slb.sample_slb.name}"
+  network_type = "vpc"
+  vpc_id = "${alicloud_vpc.sample_vpc.id}"
+  vswitch_id = "${alicloud_vswitch.sample_vswitch.id}"
+  address = "${alicloud_slb.sample_slb.address}"
+}
+`

--- a/alicloud/provider.go
+++ b/alicloud/provider.go
@@ -90,6 +90,7 @@ func Provider() terraform.ResourceProvider {
 			"alicloud_ram_policies":         dataSourceAlicloudRamPolicies(),
 			"alicloud_security_groups":      dataSourceAlicloudSecurityGroups(),
 			"alicloud_security_group_rules": dataSourceAlicloudSecurityGroupRules(),
+			"alicloud_slbs":                 dataSourceAlicloudSlbs(),
 			"alicloud_db_instances":         dataSourceAlicloudDBInstances(),
 			"alicloud_pvtz_zones":           dataSourceAlicloudPvtzZones(),
 			"alicloud_pvtz_zone_records":    dataSourceAlicloudPvtzZoneRecords(),

--- a/website/alicloud.erb
+++ b/website/alicloud.erb
@@ -52,6 +52,9 @@
                         <li<%= sidebar_current("docs-alicloud-datasource-security-group-rules") %>>
                             <a href="/docs/providers/alicloud/d/security_group_rules.html">alicloud_security_group_rules</a>
                         </li>
+                        <li<%= sidebar_current("docs-alicloud-datasource-slbs") %>>
+                            <a href="/docs/providers/alicloud/d/slbs.html">alicloud_slbs</a>
+                        </li>
                         <li<%= sidebar_current("docs-alicloud-datasource-db-instances") %>>
                             <a href="/docs/providers/alicloud/d/db_instances.html">alicloud_db_instances</a>
                         </li>

--- a/website/docs/d/slbs.html.markdown
+++ b/website/docs/d/slbs.html.markdown
@@ -1,0 +1,55 @@
+---
+layout: "alicloud"
+page_title: "Alicloud: alicloud_slbs"
+sidebar_current: "docs-alicloud-datasource-slbs"
+description: |-
+    Provides a list of server load balancers to the user.
+---
+
+# alicloud\_slbs
+
+This data source provides the server load balancers of the current Alibaba Cloud user.
+
+## Example Usage
+
+```
+data "alicloud_slbs" "slbs_ds" {
+  name_regex = "sample_slb"
+}
+
+output "first_slb_id" {
+  value = "${data.alicloud_slbs.slbs_ds.slbs.0.id}"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `ids` - (Optional) A list of SLBs IDs.
+* `name_regex` - (Optional) A regex string to filter results by SLB name.
+* `master_availability_zone` - (Optional) Master availability zone of the SLBs.
+* `slave_availability_zone` - (Optional) Slave availability zone of the SLBs.
+* `network_type` - (Optional) Network type of the SLBs. Valid values: `vpc` and `classic`.
+* `vpc_id` - (Optional) ID of the VPC linked to the SLBs.
+* `vswitch_id` - (Optional) ID of the VSwitch linked to the SLBs.
+* `address` - (Optional) Service address of the SLBs.
+* `output_file` - (Optional) File name where to save data source results (after running `terraform plan`).
+
+## Attributes Reference
+
+The following attributes are exported in addition to the arguments listed above:
+
+* `slbs` - A list of SLBs. Each element contains the following attributes:
+  * `id` - ID of the SLB.
+  * `region_id` - Region ID the SLB belongs to.
+  * `master_availability_zone` - Master availability zone of the SLBs.
+  * `slave_availability_zone` - Slave availability zone of the SLBs.
+  * `status` - SLB current status. Possible values: `inactive`, `active` and `locked`.
+  * `name` - SLB name.
+  * `network_type` - Network type of the SLB. Possible values: `vpc` and `classic`.
+  * `vpc_id` - ID of the VPC the SLB belongs to.
+  * `vswitch_id` - ID of the VSwitch the SLB belongs to.
+  * `address` - Service address of the SLB.
+  * `internet` - SLB addressType: internet if `true`, intranet if `false`. Must be `false` when `network_type` is `vpc`.
+  * `creation_time` - SLB creation time.


### PR DESCRIPTION
Split of: https://github.com/alibaba/terraform-provider/pull/653

Test results.
```
GOROOT=/usr/local/go #gosetup
GOPATH=/Users/marcplouhinec/go #gosetup
/usr/local/go/bin/go test -c -i -o /private/var/folders/v1/jvjz3zmn64q0j34yc9m9n4w00000gn/T/___non_verbose_tests github.com/alibaba/terraform-provider/alicloud #gosetup
/usr/local/go/bin/go tool test2json -t /private/var/folders/v1/jvjz3zmn64q0j34yc9m9n4w00000gn/T/___non_verbose_tests -test.v -test.run ^TestAccAlicloudSlbsDataSource #gosetup
=== RUN   TestAccAlicloudSlbsDataSource_basic
--- PASS: TestAccAlicloudSlbsDataSource_basic (59.40s)
=== RUN   TestAccAlicloudSlbsDataSource_filterByIds
--- PASS: TestAccAlicloudSlbsDataSource_filterByIds (53.51s)
=== RUN   TestAccAlicloudSlbsDataSource_filterByAllFields
--- PASS: TestAccAlicloudSlbsDataSource_filterByAllFields (51.80s)
PASS
```