### PR TITLE
New datasource alicloud_slb_listeners.

### DIFF
--- a/alicloud/data_source_alicloud_slb_listeners.go
+++ b/alicloud/data_source_alicloud_slb_listeners.go
@@ -1,0 +1,372 @@
+package alicloud
+
+import (
+	"fmt"
+	"log"
+	"strconv"
+
+	"github.com/aliyun/alibaba-cloud-sdk-go/sdk/requests"
+	"github.com/aliyun/alibaba-cloud-sdk-go/services/slb"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func dataSourceAlicloudSlbListeners() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAlicloudSlbListenersRead,
+
+		Schema: map[string]*schema.Schema{
+			"load_balancer_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"frontend_port": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				ForceNew: true,
+			},
+			"protocol": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+
+			// Computed values
+			"slb_listeners": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"frontend_port": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"backend_port": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"protocol": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"status": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"security_status": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"bandwidth": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"scheduler": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"server_group_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"master_slave_server_group_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"persistence_timeout": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"established_timeout": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"sticky_session": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"sticky_session_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"cookie_timeout": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"cookie": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"health_check": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"health_check_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"health_check_domain": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"health_check_uri": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"health_check_connect_port": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"health_check_connect_timeout": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"healthy_threshold": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"unhealthy_threshold": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"health_check_timeout": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"health_check_interval": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"health_check_http_code": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"gzip": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"ssl_certificate_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"ca_certificate_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"x_forwarded_for": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"x_forwarded_for_slb_ip": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"x_forwarded_for_slb_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"x_forwarded_for_slb_proto": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceAlicloudSlbListenersRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AliyunClient).slbconn
+
+	args := slb.CreateDescribeLoadBalancerAttributeRequest()
+	args.LoadBalancerId = d.Get("load_balancer_id").(string)
+
+	resp, err := conn.DescribeLoadBalancerAttribute(args)
+	if err != nil {
+		return fmt.Errorf("DescribeLoadBalancerAttribute got an error: %#v", err)
+	}
+	if resp == nil {
+		return fmt.Errorf("there is no SLB with the ID %s. Please change your search criteria and try again", args.LoadBalancerId)
+	}
+
+	var filteredListenersTemp []slb.ListenerPortAndProtocol
+	port := -1
+	if v, ok := d.GetOk("frontend_port"); ok && v.(int) != 0 {
+		port = v.(int)
+	}
+	protocol := ""
+	if v, ok := d.GetOk("protocol"); ok && v.(string) != "" {
+		protocol = v.(string)
+	}
+	if port != -1 && protocol != "" {
+		for _, listener := range resp.ListenerPortsAndProtocol.ListenerPortAndProtocol {
+			if port != -1 && listener.ListenerPort != port {
+				continue
+			}
+			if protocol != "" && listener.ListenerProtocol != protocol {
+				continue
+			}
+
+			filteredListenersTemp = append(filteredListenersTemp, listener)
+		}
+	} else {
+		filteredListenersTemp = resp.ListenerPortsAndProtocol.ListenerPortAndProtocol
+	}
+
+	if len(filteredListenersTemp) < 1 {
+		return fmt.Errorf("Your query returned no results. Please change your search criteria and try again.")
+	}
+
+	log.Printf("[DEBUG] alicloud_slb_listeners - Slb listeners found: %#v", filteredListenersTemp)
+
+	return slbListenersDescriptionAttributes(d, filteredListenersTemp, meta)
+}
+
+func slbListenersDescriptionAttributes(d *schema.ResourceData, listeners []slb.ListenerPortAndProtocol, meta interface{}) error {
+	conn := meta.(*AliyunClient).slbconn
+
+	var ids []string
+	var s []map[string]interface{}
+
+	for _, listener := range listeners {
+		mapping := map[string]interface{}{
+			"frontend_port": listener.ListenerPort,
+			"protocol":      listener.ListenerProtocol,
+		}
+
+		loadBalancerId := d.Get("load_balancer_id").(string)
+		switch Protocol(listener.ListenerProtocol) {
+		case Http:
+			args := slb.CreateDescribeLoadBalancerHTTPListenerAttributeRequest()
+			args.LoadBalancerId = loadBalancerId
+			args.ListenerPort = requests.NewInteger(listener.ListenerPort)
+			resp, err := conn.DescribeLoadBalancerHTTPListenerAttribute(args)
+			if err == nil {
+				mapping["backend_port"] = resp.BackendServerPort
+				mapping["status"] = resp.Status
+				mapping["bandwidth"] = resp.Bandwidth
+				mapping["scheduler"] = resp.Scheduler
+				mapping["server_group_id"] = resp.VServerGroupId
+				mapping["sticky_session"] = resp.StickySession
+				mapping["sticky_session_type"] = resp.StickySessionType
+				mapping["cookie_timeout"] = resp.CookieTimeout
+				mapping["cookie"] = resp.Cookie
+				mapping["health_check"] = resp.HealthCheck
+				mapping["health_check_domain"] = resp.HealthCheckDomain
+				mapping["health_check_uri"] = resp.HealthCheckURI
+				mapping["health_check_connect_port"] = resp.HealthCheckConnectPort
+				mapping["healthy_threshold"] = resp.HealthyThreshold
+				mapping["unhealthy_threshold"] = resp.UnhealthyThreshold
+				mapping["health_check_timeout"] = resp.HealthCheckTimeout
+				mapping["health_check_interval"] = resp.HealthCheckInterval
+				mapping["health_check_http_code"] = resp.HealthCheckHttpCode
+				mapping["gzip"] = resp.Gzip
+				mapping["x_forwarded_for"] = resp.XForwardedFor
+				mapping["x_forwarded_for_slb_ip"] = resp.XForwardedForSLBIP
+				mapping["x_forwarded_for_slb_id"] = resp.XForwardedForSLBID
+				mapping["x_forwarded_for_slb_proto"] = resp.XForwardedForProto
+			} else {
+				log.Printf("[WARN] alicloud_slb_listeners - DescribeLoadBalancerHTTPListenerAttribute error: %v", err)
+			}
+		case Https:
+			args := slb.CreateDescribeLoadBalancerHTTPSListenerAttributeRequest()
+			args.LoadBalancerId = loadBalancerId
+			args.ListenerPort = requests.NewInteger(listener.ListenerPort)
+			resp, err := conn.DescribeLoadBalancerHTTPSListenerAttribute(args)
+			if err == nil {
+				mapping["backend_port"] = resp.BackendServerPort
+				mapping["status"] = resp.Status
+				mapping["security_status"] = resp.SecurityStatus
+				mapping["bandwidth"] = resp.Bandwidth
+				mapping["scheduler"] = resp.Scheduler
+				mapping["server_group_id"] = resp.VServerGroupId
+				mapping["sticky_session"] = resp.StickySession
+				mapping["sticky_session_type"] = resp.StickySessionType
+				mapping["cookie_timeout"] = resp.CookieTimeout
+				mapping["cookie"] = resp.Cookie
+				mapping["health_check"] = resp.HealthCheck
+				mapping["health_check_domain"] = resp.HealthCheckDomain
+				mapping["health_check_uri"] = resp.HealthCheckURI
+				mapping["health_check_connect_port"] = resp.HealthCheckConnectPort
+				mapping["healthy_threshold"] = resp.HealthyThreshold
+				mapping["unhealthy_threshold"] = resp.UnhealthyThreshold
+				mapping["health_check_timeout"] = resp.HealthCheckTimeout
+				mapping["health_check_interval"] = resp.HealthCheckInterval
+				mapping["health_check_http_code"] = resp.HealthCheckHttpCode
+				mapping["gzip"] = resp.Gzip
+				mapping["ssl_certificate_id"] = resp.ServerCertificateId
+				mapping["ca_certificate_id"] = resp.CACertificateId
+				mapping["x_forwarded_for"] = resp.XForwardedFor
+				mapping["x_forwarded_for_slb_ip"] = resp.XForwardedForSLBIP
+				mapping["x_forwarded_for_slb_id"] = resp.XForwardedForSLBID
+				mapping["x_forwarded_for_slb_proto"] = resp.XForwardedForProto
+			} else {
+				log.Printf("[WARN] alicloud_slb_listeners - DescribeLoadBalancerHTTPSListenerAttribute error: %v", err)
+			}
+		case Tcp:
+			args := slb.CreateDescribeLoadBalancerTCPListenerAttributeRequest()
+			args.LoadBalancerId = loadBalancerId
+			args.ListenerPort = requests.NewInteger(listener.ListenerPort)
+			resp, err := conn.DescribeLoadBalancerTCPListenerAttribute(args)
+			if err == nil {
+				mapping["backend_port"] = resp.BackendServerPort
+				mapping["status"] = resp.Status
+				mapping["bandwidth"] = resp.Bandwidth
+				mapping["scheduler"] = resp.Scheduler
+				mapping["server_group_id"] = resp.VServerGroupId
+				mapping["master_slave_server_group_id"] = resp.MasterSlaveServerGroupId
+				mapping["persistence_timeout"] = resp.PersistenceTimeout
+				mapping["established_timeout"] = resp.EstablishedTimeout
+				mapping["health_check"] = resp.HealthCheck
+				mapping["health_check_type"] = resp.HealthCheckType
+				mapping["health_check_domain"] = resp.HealthCheckDomain
+				mapping["health_check_uri"] = resp.HealthCheckURI
+				mapping["health_check_connect_port"] = resp.HealthCheckConnectPort
+				mapping["health_check_connect_timeout"] = resp.HealthCheckConnectTimeout
+				mapping["healthy_threshold"] = resp.HealthyThreshold
+				mapping["unhealthy_threshold"] = resp.UnhealthyThreshold
+				mapping["health_check_interval"] = resp.HealthCheckInterval
+				mapping["health_check_http_code"] = resp.HealthCheckHttpCode
+			} else {
+				log.Printf("[WARN] alicloud_slb_listeners - DescribeLoadBalancerTCPListenerAttribute error: %v", err)
+			}
+		case Udp:
+			args := slb.CreateDescribeLoadBalancerUDPListenerAttributeRequest()
+			args.LoadBalancerId = loadBalancerId
+			args.ListenerPort = requests.NewInteger(listener.ListenerPort)
+			resp, err := conn.DescribeLoadBalancerUDPListenerAttribute(args)
+			if err == nil {
+				mapping["backend_port"] = resp.BackendServerPort
+				mapping["status"] = resp.Status
+				mapping["bandwidth"] = resp.Bandwidth
+				mapping["scheduler"] = resp.Scheduler
+				mapping["server_group_id"] = resp.VServerGroupId
+				mapping["master_slave_server_group_id"] = resp.MasterSlaveServerGroupId
+				mapping["persistence_timeout"] = resp.PersistenceTimeout
+				mapping["health_check"] = resp.HealthCheck
+				mapping["health_check_connect_port"] = resp.HealthCheckConnectPort
+				mapping["health_check_connect_timeout"] = resp.HealthCheckConnectTimeout
+				mapping["healthy_threshold"] = resp.HealthyThreshold
+				mapping["unhealthy_threshold"] = resp.UnhealthyThreshold
+				mapping["health_check_interval"] = resp.HealthCheckInterval
+			} else {
+				log.Printf("[WARN] alicloud_slb_listeners - DescribeLoadBalancerUDPListenerAttribute error: %v", err)
+			}
+		}
+
+		log.Printf("[DEBUG] alicloud_slb_listeners - adding slb_listener mapping: %v", mapping)
+		ids = append(ids, strconv.Itoa(listener.ListenerPort))
+		s = append(s, mapping)
+	}
+
+	d.SetId(dataResourceIdHash(ids))
+	if err := d.Set("slb_listeners", s); err != nil {
+		return err
+	}
+
+	// create a json file in current directory and write data source to it.
+	if output, ok := d.GetOk("output_file"); ok && output.(string) != "" {
+		writeToFile(output.(string), s)
+	}
+	return nil
+}

--- a/alicloud/data_source_alicloud_slb_listeners_test.go
+++ b/alicloud/data_source_alicloud_slb_listeners_test.go
@@ -1,0 +1,256 @@
+package alicloud
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccAlicloudSlbListenersDataSource_http(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckAlicloudSlbListenersDataSourceHttp,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAlicloudDataSourceID("data.alicloud_slb_listeners.slb_listeners"),
+					resource.TestCheckResourceAttr("data.alicloud_slb_listeners.slb_listeners", "slb_listeners.#", "1"),
+					resource.TestCheckResourceAttr("data.alicloud_slb_listeners.slb_listeners", "slb_listeners.0.backend_port", "80"),
+					resource.TestCheckResourceAttr("data.alicloud_slb_listeners.slb_listeners", "slb_listeners.0.frontend_port", "80"),
+					resource.TestCheckResourceAttr("data.alicloud_slb_listeners.slb_listeners", "slb_listeners.0.protocol", "http"),
+					resource.TestCheckResourceAttr("data.alicloud_slb_listeners.slb_listeners", "slb_listeners.0.status", "running"),
+					resource.TestCheckResourceAttr("data.alicloud_slb_listeners.slb_listeners", "slb_listeners.0.bandwidth", "10"),
+					resource.TestCheckResourceAttr("data.alicloud_slb_listeners.slb_listeners", "slb_listeners.0.scheduler", "wrr"),
+					resource.TestCheckResourceAttr("data.alicloud_slb_listeners.slb_listeners", "slb_listeners.0.sticky_session", "on"),
+					resource.TestCheckResourceAttr("data.alicloud_slb_listeners.slb_listeners", "slb_listeners.0.sticky_session_type", "insert"),
+					resource.TestCheckResourceAttr("data.alicloud_slb_listeners.slb_listeners", "slb_listeners.0.cookie_timeout", "86400"),
+					resource.TestCheckResourceAttr("data.alicloud_slb_listeners.slb_listeners", "slb_listeners.0.health_check", "on"),
+					resource.TestCheckResourceAttr("data.alicloud_slb_listeners.slb_listeners", "slb_listeners.0.health_check_uri", "/cons"),
+					resource.TestCheckResourceAttr("data.alicloud_slb_listeners.slb_listeners", "slb_listeners.0.health_check_connect_port", "20"),
+					resource.TestCheckResourceAttr("data.alicloud_slb_listeners.slb_listeners", "slb_listeners.0.healthy_threshold", "8"),
+					resource.TestCheckResourceAttr("data.alicloud_slb_listeners.slb_listeners", "slb_listeners.0.unhealthy_threshold", "8"),
+					resource.TestCheckResourceAttr("data.alicloud_slb_listeners.slb_listeners", "slb_listeners.0.health_check_timeout", "8"),
+					resource.TestCheckResourceAttr("data.alicloud_slb_listeners.slb_listeners", "slb_listeners.0.health_check_interval", "5"),
+					resource.TestCheckResourceAttr("data.alicloud_slb_listeners.slb_listeners", "slb_listeners.0.health_check_http_code", "http_2xx,http_3xx"),
+					resource.TestCheckResourceAttr("data.alicloud_slb_listeners.slb_listeners", "slb_listeners.0.gzip", "on"),
+					resource.TestCheckResourceAttr("data.alicloud_slb_listeners.slb_listeners", "slb_listeners.0.x_forwarded_for", "on"),
+					resource.TestCheckResourceAttr("data.alicloud_slb_listeners.slb_listeners", "slb_listeners.0.x_forwarded_for_slb_ip", "on"),
+					resource.TestCheckResourceAttr("data.alicloud_slb_listeners.slb_listeners", "slb_listeners.0.x_forwarded_for_slb_id", "on"),
+					resource.TestCheckResourceAttr("data.alicloud_slb_listeners.slb_listeners", "slb_listeners.0.x_forwarded_for_slb_proto", "off"),
+
+					testAccCheckAlicloudDataSourceID("data.alicloud_slb_listeners.slb_listeners_with_filters"),
+					resource.TestCheckResourceAttr("data.alicloud_slb_listeners.slb_listeners_with_filters", "slb_listeners.#", "1"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAlicloudSlbListenersDataSource_tcp(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckAlicloudSlbListenersDataSourceTcp,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAlicloudDataSourceID("data.alicloud_slb_listeners.slb_listeners"),
+					resource.TestCheckResourceAttr("data.alicloud_slb_listeners.slb_listeners", "slb_listeners.#", "1"),
+					resource.TestCheckResourceAttr("data.alicloud_slb_listeners.slb_listeners", "slb_listeners.0.backend_port", "22"),
+					resource.TestCheckResourceAttr("data.alicloud_slb_listeners.slb_listeners", "slb_listeners.0.frontend_port", "22"),
+					resource.TestCheckResourceAttr("data.alicloud_slb_listeners.slb_listeners", "slb_listeners.0.protocol", "tcp"),
+					resource.TestCheckResourceAttr("data.alicloud_slb_listeners.slb_listeners", "slb_listeners.0.status", "running"),
+					resource.TestCheckResourceAttr("data.alicloud_slb_listeners.slb_listeners", "slb_listeners.0.bandwidth", "10"),
+					resource.TestCheckResourceAttr("data.alicloud_slb_listeners.slb_listeners", "slb_listeners.0.scheduler", "wrr"),
+					resource.TestCheckResourceAttr("data.alicloud_slb_listeners.slb_listeners", "slb_listeners.0.persistence_timeout", "0"),
+					resource.TestCheckResourceAttr("data.alicloud_slb_listeners.slb_listeners", "slb_listeners.0.established_timeout", "900"),
+					resource.TestCheckResourceAttr("data.alicloud_slb_listeners.slb_listeners", "slb_listeners.0.health_check", "on"),
+					resource.TestCheckResourceAttr("data.alicloud_slb_listeners.slb_listeners", "slb_listeners.0.health_check_type", "tcp"),
+					resource.TestCheckResourceAttr("data.alicloud_slb_listeners.slb_listeners", "slb_listeners.0.health_check_connect_port", "20"),
+					resource.TestCheckResourceAttr("data.alicloud_slb_listeners.slb_listeners", "slb_listeners.0.health_check_connect_timeout", "8"),
+					resource.TestCheckResourceAttr("data.alicloud_slb_listeners.slb_listeners", "slb_listeners.0.healthy_threshold", "8"),
+					resource.TestCheckResourceAttr("data.alicloud_slb_listeners.slb_listeners", "slb_listeners.0.unhealthy_threshold", "8"),
+					resource.TestCheckResourceAttr("data.alicloud_slb_listeners.slb_listeners", "slb_listeners.0.health_check_timeout", "0"),
+					resource.TestCheckResourceAttr("data.alicloud_slb_listeners.slb_listeners", "slb_listeners.0.health_check_interval", "5"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAlicloudSlbListenersDataSource_udp(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckAlicloudSlbListenersDataSourceUdp,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAlicloudDataSourceID("data.alicloud_slb_listeners.slb_listeners"),
+					resource.TestCheckResourceAttr("data.alicloud_slb_listeners.slb_listeners", "slb_listeners.#", "1"),
+					resource.TestCheckResourceAttr("data.alicloud_slb_listeners.slb_listeners", "slb_listeners.0.backend_port", "10"),
+					resource.TestCheckResourceAttr("data.alicloud_slb_listeners.slb_listeners", "slb_listeners.0.frontend_port", "11"),
+					resource.TestCheckResourceAttr("data.alicloud_slb_listeners.slb_listeners", "slb_listeners.0.protocol", "udp"),
+					resource.TestCheckResourceAttr("data.alicloud_slb_listeners.slb_listeners", "slb_listeners.0.status", "running"),
+					resource.TestCheckResourceAttr("data.alicloud_slb_listeners.slb_listeners", "slb_listeners.0.bandwidth", "10"),
+					resource.TestCheckResourceAttr("data.alicloud_slb_listeners.slb_listeners", "slb_listeners.0.scheduler", "wrr"),
+					resource.TestCheckResourceAttr("data.alicloud_slb_listeners.slb_listeners", "slb_listeners.0.health_check", "on"),
+					resource.TestCheckResourceAttr("data.alicloud_slb_listeners.slb_listeners", "slb_listeners.0.health_check_connect_port", "20"),
+					resource.TestCheckResourceAttr("data.alicloud_slb_listeners.slb_listeners", "slb_listeners.0.health_check_connect_timeout", "8"),
+					resource.TestCheckResourceAttr("data.alicloud_slb_listeners.slb_listeners", "slb_listeners.0.healthy_threshold", "8"),
+					resource.TestCheckResourceAttr("data.alicloud_slb_listeners.slb_listeners", "slb_listeners.0.unhealthy_threshold", "8"),
+					resource.TestCheckResourceAttr("data.alicloud_slb_listeners.slb_listeners", "slb_listeners.0.health_check_timeout", "0"),
+					resource.TestCheckResourceAttr("data.alicloud_slb_listeners.slb_listeners", "slb_listeners.0.health_check_interval", "5"),
+				),
+			},
+		},
+	})
+}
+
+const testAccCheckAlicloudSlbListenersDataSourceHttp = `
+variable "name" {
+	default = "testAccCheckAlicloudSlbListenersDataSourceHttp"
+}
+
+data "alicloud_zones" "az" {
+	"available_resource_creation"= "VSwitch"
+}
+
+resource "alicloud_vpc" "sample_vpc" {
+  name = "${var.name}"
+  cidr_block = "172.16.0.0/12"
+}
+
+resource "alicloud_vswitch" "sample_vswitch" {
+  vpc_id = "${alicloud_vpc.sample_vpc.id}"
+  cidr_block = "172.16.0.0/16"
+  availability_zone = "${data.alicloud_zones.az.zones.0.id}"
+}
+
+resource "alicloud_slb" "sample_slb" {
+  name = "${var.name}"
+  vswitch_id = "${alicloud_vswitch.sample_vswitch.id}"
+}
+
+resource "alicloud_slb_listener" "sample_slb_listener" {
+  load_balancer_id = "${alicloud_slb.sample_slb.id}"
+  backend_port = 80
+  frontend_port = 80
+  protocol = "http"
+  sticky_session = "on"
+  sticky_session_type = "insert"
+  cookie = "${var.name}"
+  cookie_timeout = 86400
+  health_check = "on"
+  health_check_uri = "/cons"
+  health_check_connect_port = 20
+  healthy_threshold = 8
+  unhealthy_threshold = 8
+  health_check_timeout = 8
+  health_check_interval = 5
+  health_check_http_code = "http_2xx,http_3xx"
+  bandwidth = 10
+  x_forwarded_for = {
+    retrive_slb_ip = true
+    retrive_slb_id = true
+  }
+}
+
+data "alicloud_slb_listeners" "slb_listeners" {
+  load_balancer_id = "${alicloud_slb_listener.sample_slb_listener.load_balancer_id}"
+}
+
+data "alicloud_slb_listeners" "slb_listeners_with_filters" {
+  load_balancer_id = "${alicloud_slb_listener.sample_slb_listener.load_balancer_id}"
+  frontend_port = 80
+  protocol = "http"
+}
+`
+
+const testAccCheckAlicloudSlbListenersDataSourceTcp = `
+variable "name" {
+	default = "testAccCheckAlicloudSlbListenersDataSourceTcp"
+}
+
+data "alicloud_zones" "az" {
+	"available_resource_creation"= "VSwitch"
+}
+
+resource "alicloud_vpc" "sample_vpc" {
+  name = "${var.name}"
+  cidr_block = "172.16.0.0/12"
+}
+
+resource "alicloud_vswitch" "sample_vswitch" {
+  vpc_id = "${alicloud_vpc.sample_vpc.id}"
+  cidr_block = "172.16.0.0/16"
+  availability_zone = "${data.alicloud_zones.az.zones.0.id}"
+}
+
+resource "alicloud_slb" "sample_slb" {
+  name = "${var.name}"
+  vswitch_id = "${alicloud_vswitch.sample_vswitch.id}"
+}
+
+resource "alicloud_slb_listener" "sample_slb_listener" {
+  load_balancer_id = "${alicloud_slb.sample_slb.id}"
+  backend_port = 22
+  frontend_port = 22
+  protocol = "tcp"
+  health_check_connect_port = 20
+  healthy_threshold = 8
+  unhealthy_threshold = 8
+  health_check_timeout = 8
+  health_check_interval = 5
+  health_check_type = "tcp"
+  bandwidth = 10
+}
+
+data "alicloud_slb_listeners" "slb_listeners" {
+  load_balancer_id = "${alicloud_slb_listener.sample_slb_listener.load_balancer_id}"
+}
+`
+
+const testAccCheckAlicloudSlbListenersDataSourceUdp = `
+variable "name" {
+	default = "testAccCheckAlicloudSlbListenersDataSourceUdp"
+}
+
+data "alicloud_zones" "az" {
+	"available_resource_creation"= "VSwitch"
+}
+
+resource "alicloud_vpc" "sample_vpc" {
+  name = "${var.name}"
+  cidr_block = "172.16.0.0/12"
+}
+
+resource "alicloud_vswitch" "sample_vswitch" {
+  vpc_id = "${alicloud_vpc.sample_vpc.id}"
+  cidr_block = "172.16.0.0/16"
+  availability_zone = "${data.alicloud_zones.az.zones.0.id}"
+}
+
+resource "alicloud_slb" "sample_slb" {
+  name = "${var.name}"
+  vswitch_id = "${alicloud_vswitch.sample_vswitch.id}"
+}
+
+resource "alicloud_slb_listener" "sample_slb_listener" {
+  load_balancer_id = "${alicloud_slb.sample_slb.id}"
+  backend_port = 10
+  frontend_port = 11
+  protocol = "udp"
+  health_check_connect_port = 20
+  healthy_threshold = 8
+  unhealthy_threshold = 8
+  health_check_timeout = 8
+  health_check_interval = 5
+  bandwidth = 10
+}
+
+data "alicloud_slb_listeners" "slb_listeners" {
+  load_balancer_id = "${alicloud_slb_listener.sample_slb_listener.load_balancer_id}"
+}
+`

--- a/alicloud/provider.go
+++ b/alicloud/provider.go
@@ -90,6 +90,7 @@ func Provider() terraform.ResourceProvider {
 			"alicloud_ram_policies":         dataSourceAlicloudRamPolicies(),
 			"alicloud_security_groups":      dataSourceAlicloudSecurityGroups(),
 			"alicloud_security_group_rules": dataSourceAlicloudSecurityGroupRules(),
+			"alicloud_slb_listeners":        dataSourceAlicloudSlbListeners(),
 			"alicloud_db_instances":         dataSourceAlicloudDBInstances(),
 			"alicloud_pvtz_zones":           dataSourceAlicloudPvtzZones(),
 			"alicloud_pvtz_zone_records":    dataSourceAlicloudPvtzZoneRecords(),

--- a/website/alicloud.erb
+++ b/website/alicloud.erb
@@ -52,6 +52,9 @@
                         <li<%= sidebar_current("docs-alicloud-datasource-security-group-rules") %>>
                             <a href="/docs/providers/alicloud/d/security_group_rules.html">alicloud_security_group_rules</a>
                         </li>
+                        <li<%= sidebar_current("docs-alicloud-datasource-slb-listeners") %>>
+                            <a href="/docs/providers/alicloud/d/slb_listeners.html">alicloud_slb_listeners</a>
+                        </li>
                         <li<%= sidebar_current("docs-alicloud-datasource-db-instances") %>>
                             <a href="/docs/providers/alicloud/d/db_instances.html">alicloud_db_instances</a>
                         </li>

--- a/website/docs/d/slb_listeners.html.markdown
+++ b/website/docs/d/slb_listeners.html.markdown
@@ -1,0 +1,71 @@
+---
+layout: "alicloud"
+page_title: "Alicloud: alicloud_slb_listeners"
+sidebar_current: "docs-alicloud-datasource-slb-listeners"
+description: |-
+    Provides a list of server load balancer listeners to the user.
+---
+
+# alicloud\_slb_listeners
+
+This data source provides the listeners related to a server load balancer of the current Alibaba Cloud user.
+
+## Example Usage
+
+```
+data "alicloud_slb_listeners" "sample_ds" {
+  load_balancer_id = "${alicloud_slb.sample_slb.id}"
+}
+
+output "first_slb_listener_protocol" {
+  value = "${data.alicloud_slb_listeners.sample_ds.slb_listeners.0.protocol}"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `load_balancer_id` - ID of the SLB with listeners.
+* `protocol` - (Optional) Filter listeners by the specified protocol. Valid values: `http`, `https`, `tcp` and `udp`.
+* `frontend_port` - (Optional) Filter listeners by the specified frontend port.
+* `output_file` - (Optional) File name where to save data source results (after running `terraform plan`).
+
+## Attributes Reference
+
+The following attributes are exported in addition to the arguments listed above:
+
+* `slb_listeners` - A list of SLB listeners. Each element contains the following attributes:
+  * `frontend_port` - Frontend port used to receive incoming traffic and distribute it to the backend servers.
+  * `backend_port` - Port opened on the backend server to receive requests.
+  * `protocol` - Listener protocol. Possible values: `http`, `https`, `tcp` and `udp`.
+  * `status` - Listener status.
+  * `security_status` - Security status. Only available when the protocol is `https`.
+  * `bandwidth` - Peak bandwidth. If the value is set to -1, the listener is not limited by bandwidth.
+  * `scheduler` - Algorithm used to distribute traffic. Possible values: `wrr` (weighted round robin), `wlc` (weighted least connection) and `rr` (round robin).
+  * `server_group_id` - ID of the linked VServer group.
+  * `master_slave_server_group_id` - ID of the active/standby server group.
+  * `persistence_timeout` - Timeout value of the TCP connection in seconds. If the value is 0, the session persistence function is disabled. Only available when the protocol is `tcp`.
+  * `established_timeout` - Connection timeout in seconds for the Layer 4 TCP listener. Only available when the protocol is `tcp`.
+  * `sticky_session` - Indicate whether session persistence is enabled or not. If enabled, all session requests from the same client are sent to the same backend server. Possible values are `on` and `off`. Only available when the protocol is `http` or `https`.
+  * `sticky_session_type` - Method used to handle the cookie. Possible values are `insert` (cookie added to the response) and `server` (cookie set by the backend server). Only available when the protocol is `http` or `https` and sticky_session is `on`.
+  * `cookie_timeout` - Cookie timeout in seconds. Only available when the sticky_session_type is `insert`.
+  * `cookie` - Cookie configured by the backend server. Only available when the sticky_session_type is `server`.
+  * `health_check` - Indicate whether health check is enabled of not. Possible values are `on` and `off`.
+  * `health_check_type` - Health check method. Possible values are `tcp` and `http`. Only available when the protocol is `tcp`.
+  * `health_check_domain` - Domain name used for health check. The SLB sends HTTP head requests to the backend server, the domain is useful when the backend server verifies the host field in the requests. Only available when the protocol is `http`, `https` or `tcp` (in this case health_check_type must be `http`).
+  * `health_check_uri` - URI used for health check. Only available when the protocol is `http`, `https` or `tcp` (in this case health_check_type must be `http`).
+  * `health_check_connect_port` - Port used for health check.
+  * `health_check_connect_timeout` - Amount of time in seconds to wait for the response for a health check.
+  * `healthy_threshold` - Number of consecutive successes of health check performed on the same ECS instance (from failure to success).
+  * `unhealthy_threshold` - Number of consecutive failures of health check performed on the same ECS instance (from success to failure).
+  * `health_check_timeout` - Amount of time in seconds to wait for the response from a health check. If an ECS instance sends no response within the specified timeout period, the health check fails. Only available when the protocol is `http` or `https`.
+  * `health_check_interval` - Time interval between two consecutive health checks.
+  * `health_check_http_code` - HTTP status codes indicating that the health check is normal. It can contain several comma-separated values such as "http_2xx,http_3xx". Only available when the protocol is `http`, `https` or `tcp` (in this case health_check_type must be `http`).
+  * `gzip` - Indicate whether Gzip compression is enabled or not. Possible values are `on` and `off`. Only available when the protocol is `http` or `https`.
+  * `ssl_certificate_id` - ID of the server certificate. Only available when the protocol is `https`.
+  * `ca_certificate_id` - ID of the CA certificate (only required when two-way authentication is used). Only available when the protocol is `https`.
+  * `x_forwarded_for` - Indicate whether the HTTP header field "X-Forwarded-For" is added or not; it allows the backend server to know about the user's IP address. Possible values are `on` and `off`. Only available when the protocol is `http` or `https`.
+  * `x_forwarded_for_slb_ip` - Indicate whether the HTTP header field "X-Forwarded-For_SLBIP" is added or not; it allows the backend server to know about the SLB IP address. Possible values are `on` and `off`. Only available when the protocol is `http` or `https`.
+  * `x_forwarded_for_slb_id` - Indicate whether the HTTP header field "X-Forwarded-For_SLBID" is added or not; it allows the backend server to know about the SLB ID. Possible values are `on` and `off`. Only available when the protocol is `http` or `https`.
+  * `x_forwarded_for_slb_proto` - Indicate whether the HTTP header field "X-Forwarded-For_proto" is added or not; it allows the backend server to know about the user's protocol. Possible values are `on` and `off`. Only available when the protocol is `http` or `https`.


### PR DESCRIPTION
Split of: https://github.com/alibaba/terraform-provider/pull/653

Test results:
```
GOPATH=/Users/marcplouhinec/go #gosetup
/usr/local/go/bin/go test -c -i -o /private/var/folders/v1/jvjz3zmn64q0j34yc9m9n4w00000gn/T/___non_verbose_tests github.com/alibaba/terraform-provider/alicloud #gosetup
/usr/local/go/bin/go tool test2json -t /private/var/folders/v1/jvjz3zmn64q0j34yc9m9n4w00000gn/T/___non_verbose_tests -test.v -test.run ^TestAccAlicloudSlbListenersDataSource #gosetup
=== RUN   TestAccAlicloudSlbListenersDataSource_http
--- PASS: TestAccAlicloudSlbListenersDataSource_http (75.11s)
=== RUN   TestAccAlicloudSlbListenersDataSource_tcp
--- PASS: TestAccAlicloudSlbListenersDataSource_tcp (68.66s)
=== RUN   TestAccAlicloudSlbListenersDataSource_udp
--- PASS: TestAccAlicloudSlbListenersDataSource_udp (68.00s)
PASS
```