### PR TITLE
Use unique bucket names in order to allow 2 users to run the same tes…

### DIFF
--- a/alicloud/import_alicloud_fc_function_test.go
+++ b/alicloud/import_alicloud_fc_function_test.go
@@ -3,6 +3,7 @@ package alicloud
 import (
 	"testing"
 
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
@@ -20,7 +21,7 @@ func TestAccAlicloudFCFunction_import(t *testing.T) {
 		CheckDestroy: testAccCheckAlicloudFCFunctionDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAlicloudFCFunctionBasic(testFCRoleTemplate),
+				Config: testAlicloudFCFunctionBasic(testFCRoleTemplate, acctest.RandInt()),
 			},
 
 			resource.TestStep{

--- a/alicloud/import_alicloud_fc_trigger_test.go
+++ b/alicloud/import_alicloud_fc_trigger_test.go
@@ -3,6 +3,7 @@ package alicloud
 import (
 	"testing"
 
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
@@ -21,7 +22,7 @@ func SkipTestAccAlicloudFCTrigger_import(t *testing.T) {
 		CheckDestroy: testAccCheckAlicloudFCTriggerDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAlicloudFCTriggerLog(testTriggerLogTemplate, testFCLogRoleTemplate, testFCLogPolicyTemplate),
+				Config: testAlicloudFCTriggerLog(testTriggerLogTemplate, testFCLogRoleTemplate, testFCLogPolicyTemplate, acctest.RandInt()),
 			},
 
 			resource.TestStep{

--- a/alicloud/resource_alicloud_fc_function_test.go
+++ b/alicloud/resource_alicloud_fc_function_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/aliyun/aliyun-oss-go-sdk/oss"
 	"github.com/aliyun/fc-go-sdk"
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 )
@@ -22,28 +23,29 @@ func TestAccAlicloudFCFunction_basic(t *testing.T) {
 	var function fc.GetFunctionOutput
 	var bucket oss.BucketInfo
 
+	randInt := acctest.RandInt()
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAlicloudFCFunctionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAlicloudFCFunctionBasic(testFCRoleTemplate),
+				Config: testAlicloudFCFunctionBasic(testFCRoleTemplate, randInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAlicloudFCServiceExists("alicloud_fc_service.foo", &service),
 					testAccCheckAlicloudFCFunctionExists("alicloud_fc_function.foo", &function),
-					resource.TestCheckResourceAttr("alicloud_fc_function.foo", "name", "test-acc-alicloud-fc-function-basic"),
+					resource.TestCheckResourceAttr("alicloud_fc_function.foo", "name", fmt.Sprintf("test-acc-alicloud-fc-function-basic-%v", randInt)),
 					resource.TestCheckResourceAttr("alicloud_fc_function.foo", "description", "tf unit test"),
 					resource.TestCheckResourceAttr("alicloud_fc_function.foo", "runtime", "python2.7"),
 					resource.TestCheckResourceAttr("alicloud_fc_function.foo", "memory_size", "512"),
 				),
 			},
 			{
-				Config: testAlicloudFCFunctionUpdate(testFCRoleTemplate),
+				Config: testAlicloudFCFunctionUpdate(testFCRoleTemplate, randInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckOssBucketExists("alicloud_oss_bucket.foo", &bucket),
 					testAccCheckAlicloudFCFunctionExists("alicloud_fc_function.foo", &function),
-					resource.TestCheckResourceAttr("alicloud_fc_function.foo", "name", "test-acc-alicloud-fc-function-basic"),
+					resource.TestCheckResourceAttr("alicloud_fc_function.foo", "name", fmt.Sprintf("test-acc-alicloud-fc-function-basic-%v", randInt)),
 					resource.TestCheckResourceAttr("alicloud_fc_function.foo", "description", "tf unit test"),
 					resource.TestCheckResourceAttr("alicloud_fc_function.foo", "runtime", "nodejs6"),
 					resource.TestCheckResourceAttr("alicloud_fc_function.foo", "memory_size", "128"),
@@ -99,10 +101,10 @@ func testAccCheckAlicloudFCFunctionDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAlicloudFCFunctionBasic(role string) string {
+func testAlicloudFCFunctionBasic(role string, randInt int) string {
 	return fmt.Sprintf(`
 variable "name" {
-    default = "test-acc-alicloud-fc-function-basic"
+    default = "test-acc-alicloud-fc-function-basic-%v"
 }
 resource "alicloud_log_project" "foo" {
   name = "${var.name}"
@@ -164,13 +166,13 @@ resource "alicloud_ram_role_policy_attachment" "foo" {
   policy_name = "AliyunLogFullAccess"
   policy_type = "System"
 }
-`, role)
+`, randInt, role)
 }
 
-func testAlicloudFCFunctionUpdate(role string) string {
+func testAlicloudFCFunctionUpdate(role string, randInt int) string {
 	return fmt.Sprintf(`
 variable "name" {
-    default = "test-acc-alicloud-fc-function-basic"
+    default = "test-acc-alicloud-fc-function-basic-%v"
 }
 resource "alicloud_log_project" "foo" {
   name = "${var.name}"
@@ -232,5 +234,5 @@ resource "alicloud_ram_role_policy_attachment" "foo" {
   policy_name = "AliyunLogFullAccess"
   policy_type = "System"
 }
-`, role)
+`, randInt, role)
 }

--- a/alicloud/resource_alicloud_fc_trigger_test.go
+++ b/alicloud/resource_alicloud_fc_trigger_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/aliyun/aliyun-log-go-sdk"
 	"github.com/aliyun/fc-go-sdk"
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 )
@@ -24,28 +25,29 @@ func TestAccAlicloudFCTrigger_log(t *testing.T) {
 	var function fc.GetFunctionOutput
 	var trigger fc.GetTriggerOutput
 
+	randInt := acctest.RandInt()
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAlicloudFCTriggerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAlicloudFCTriggerLog(testTriggerLogTemplate, testFCLogRoleTemplate, testFCLogPolicyTemplate),
+				Config: testAlicloudFCTriggerLog(testTriggerLogTemplate, testFCLogRoleTemplate, testFCLogPolicyTemplate, randInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAlicloudLogProjectExists("alicloud_log_project.foo", &project),
 					testAccCheckAlicloudLogStoreExists("alicloud_log_store.foo", &store),
 					testAccCheckAlicloudFCServiceExists("alicloud_fc_service.foo", &service),
 					testAccCheckAlicloudFCFunctionExists("alicloud_fc_function.foo", &function),
 					testAccCheckAlicloudFCTriggerExists("alicloud_fc_trigger.foo", &trigger),
-					resource.TestCheckResourceAttr("alicloud_fc_trigger.foo", "name", "test-alicloud-fc-trigger"),
+					resource.TestCheckResourceAttr("alicloud_fc_trigger.foo", "name", fmt.Sprintf("test-alicloud-fc-trigger-%v", randInt)),
 					resource.TestCheckResourceAttrSet("alicloud_fc_trigger.foo", "config"),
 				),
 			},
 			{
-				Config: testAlicloudFCTriggerLogUpdate(testTriggerLogTemplateUpdate, testFCLogRoleTemplate, testFCLogPolicyTemplate),
+				Config: testAlicloudFCTriggerLogUpdate(testTriggerLogTemplateUpdate, testFCLogRoleTemplate, testFCLogPolicyTemplate, randInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAlicloudFCTriggerExists("alicloud_fc_trigger.foo", &trigger),
-					resource.TestCheckResourceAttr("alicloud_fc_trigger.foo", "name", "test-alicloud-fc-trigger"),
+					resource.TestCheckResourceAttr("alicloud_fc_trigger.foo", "name", fmt.Sprintf("test-alicloud-fc-trigger-%v", randInt)),
 					resource.TestCheckResourceAttrSet("alicloud_fc_trigger.foo", "config"),
 				),
 			},
@@ -103,7 +105,7 @@ func testAccCheckAlicloudFCTriggerDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAlicloudFCTriggerLog(trigger, role, policy string) string {
+func testAlicloudFCTriggerLog(trigger, role, policy string, randInt int) string {
 	return fmt.Sprintf(`
 provider "alicloud" {
   account_id = "${var.account}"
@@ -116,7 +118,7 @@ variable "account" {
   default = "1204663572767468"
 }
 variable "name" {
-  default = "test-alicloud-fc-trigger"
+  default = "test-alicloud-fc-trigger-%v"
 }
 
 resource "alicloud_log_project" "foo" {
@@ -201,10 +203,10 @@ resource "alicloud_ram_role_policy_attachment" "foo" {
   policy_name = "${alicloud_ram_policy.foo.name}"
   policy_type = "Custom"
 }
-`, trigger, role, policy)
+`, randInt, trigger, role, policy)
 }
 
-func testAlicloudFCTriggerLogUpdate(trigger, role, policy string) string {
+func testAlicloudFCTriggerLogUpdate(trigger, role, policy string, randInt int) string {
 	return fmt.Sprintf(`
 provider "alicloud" {
   account_id = "${var.account}"
@@ -217,7 +219,7 @@ variable "account" {
   default = "1204663572767468"
 }
 variable "name" {
-  default = "test-alicloud-fc-trigger"
+  default = "test-alicloud-fc-trigger-%v"
 }
 
 resource "alicloud_log_project" "foo" {
@@ -302,7 +304,7 @@ resource "alicloud_ram_role_policy_attachment" "foo" {
   policy_name = "${alicloud_ram_policy.foo.name}"
   policy_type = "Custom"
 }
-`, trigger, role, policy)
+`, randInt, trigger, role, policy)
 }
 
 var testTriggerLogTemplate = `


### PR DESCRIPTION
…ts at the same time on the same region.

Test results:
```
GOROOT=/usr/local/go #gosetup
GOPATH=/Users/marcplouhinec/go #gosetup
/usr/local/go/bin/go test -c -i -v -o /private/var/folders/v1/jvjz3zmn64q0j34yc9m9n4w00000gn/T/___Test_in_github_com_alibaba_terraform_provider_alicloud github.com/alibaba/terraform-provider/alicloud #gosetup
github.com/alibaba/terraform-provider/alicloud
github.com/alibaba/terraform-provider/alicloud (testmain)
/usr/local/go/bin/go tool test2json -t /private/var/folders/v1/jvjz3zmn64q0j34yc9m9n4w00000gn/T/___Test_in_github_com_alibaba_terraform_provider_alicloud -test.v -test.run ^TestAccAlicloudFCTrigger_log$ #gosetup
=== RUN   TestAccAlicloudFCTrigger_log
--- PASS: TestAccAlicloudFCTrigger_log (103.56s)
PASS
```

```
GOROOT=/usr/local/go #gosetup
GOPATH=/Users/marcplouhinec/go #gosetup
/usr/local/go/bin/go test -c -i -o /private/var/folders/v1/jvjz3zmn64q0j34yc9m9n4w00000gn/T/___non_verbose_tests github.com/alibaba/terraform-provider/alicloud #gosetup
/usr/local/go/bin/go tool test2json -t /private/var/folders/v1/jvjz3zmn64q0j34yc9m9n4w00000gn/T/___non_verbose_tests -test.v -test.run ^TestAccAlicloudFCFunction_basic$ #gosetup
=== RUN   TestAccAlicloudFCFunction_basic
--- PASS: TestAccAlicloudFCFunction_basic (107.76s)
PASS
```