### PR TITLE
Allow TestAccAlicloudSlbAttachment_basic to run outside of China by c…

### DIFF
--- a/alicloud/resource_alicloud_slb_attachment_test.go
+++ b/alicloud/resource_alicloud_slb_attachment_test.go
@@ -119,7 +119,7 @@ resource "alicloud_instance" "foo" {
 
 	# series III
 	instance_type = "${data.alicloud_instance_types.default.instance_types.0.id}"
-	internet_charge_type = "PayByBandwidth"
+	internet_charge_type = "PayByTraffic"
 	internet_max_bandwidth_out = "5"
 	system_disk_category = "cloud_efficiency"
 


### PR DESCRIPTION
…hanging internet_charge_type from PayByBandwidth to PayByTraffic.

Test result:
```
GOROOT=/usr/local/go #gosetup
GOPATH=/Users/marcplouhinec/go #gosetup
/usr/local/go/bin/go test -c -i -sweep=eu-central-1 -o /private/var/folders/v1/jvjz3zmn64q0j34yc9m9n4w00000gn/T/___non_verbose_tests github.com/alibaba/terraform-provider/alicloud #gosetup
/usr/local/go/bin/go tool test2json -t /private/var/folders/v1/jvjz3zmn64q0j34yc9m9n4w00000gn/T/___non_verbose_tests -test.v -test.run ^TestAccAlicloudSlbAttachment_basic$ #gosetup
=== RUN   TestAccAlicloudSlbAttachment_basic
2018/09/06 16:43:58 [ERROR] DescribeTags for image got error: &alicloud.ProviderError{errorCode:"Instance.Notfound", message:"Describe image tag by id ubuntu_14_0405_64_20G_alibase_20170824.vhd got an error."}
2018/09/06 16:46:05 testCheckAttr slb BackendServers is: slb.BackendServersInDescribeLoadBalancerAttribute{BackendServer:[]slb.BackendServer{slb.BackendServer{Port:0, ServerHealthStatus:"", VmName:"", ServerId:"i-gw89je7fi75kbsapt342", NetworkType:"", ListenerPort:0, Weight:90}}}
2018/09/06 16:46:05 slb bacnendservers: []slb.BackendServer{slb.BackendServer{Port:0, ServerHealthStatus:"", VmName:"", ServerId:"i-gw89je7fi75kbsapt342", NetworkType:"", ListenerPort:0, Weight:90}}
2018/09/06 16:46:08 [ERROR] DescribeTags for image got error: &alicloud.ProviderError{errorCode:"Instance.Notfound", message:"Describe image tag by id ubuntu_14_0405_64_20G_alibase_20170824.vhd got an error."}
2018/09/06 16:46:14 [ERROR] DescribeTags for image got error: &alicloud.ProviderError{errorCode:"Instance.Notfound", message:"Describe image tag by id ubuntu_14_0405_64_20G_alibase_20170824.vhd got an error."}
2018/09/06 16:47:06 [ERROR] DescribeTags for image got error: &alicloud.ProviderError{errorCode:"Instance.Notfound", message:"Describe image tag by id ubuntu_14_0405_64_20G_alibase_20170824.vhd got an error."}
--- PASS: TestAccAlicloudSlbAttachment_basic (191.77s)
PASS
```