### PR TITLE
Fix alicloud db connection

### DIFF
--- a/alicloud/common.go
+++ b/alicloud/common.go
@@ -296,8 +296,6 @@ func userDataHashSum(user_data string) string {
 	return string(v)
 }
 
-const DBConnectionSuffix = ".mysql.rds.aliyuncs.com"
-
 // Remove useless blank in the string.
 func Trim(v string) string {
 	if len(v) < 1 {

--- a/alicloud/resource_alicloud_db_connection.go
+++ b/alicloud/resource_alicloud_db_connection.go
@@ -12,7 +12,7 @@ import (
 	"github.com/hashicorp/terraform/helper/schema"
 )
 
-const dbConnectionSuffixRegex = "\\.mysql\\.([a-zA-Z0-9\\-_]+\\.){0,1}rds\\.aliyuncs\\.com"
+const dbConnectionSuffixRegex = "\\.mysql\\.([a-zA-Z0-9\\-]+\\.){0,1}rds\\.aliyuncs\\.com"
 const dbConnectionIdWithSuffixRegex = "^([a-zA-Z0-9\\-_]+:[a-zA-Z0-9\\-_]+)" + dbConnectionSuffixRegex + "$"
 
 var dbConnectionIdWithSuffixRegexp = regexp.MustCompile(dbConnectionIdWithSuffixRegex)

--- a/alicloud/resource_alicloud_db_connection.go
+++ b/alicloud/resource_alicloud_db_connection.go
@@ -5,10 +5,17 @@ import (
 	"strings"
 	"time"
 
+	"regexp"
+
 	"github.com/aliyun/alibaba-cloud-sdk-go/services/rds"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
 )
+
+const dbConnectionSuffixRegex = "\\.mysql\\.([a-zA-Z0-9\\-_]+\\.){0,1}rds\\.aliyuncs\\.com"
+const dbConnectionIdWithSuffixRegex = "^([a-zA-Z0-9\\-_]+:[a-zA-Z0-9\\-_]+)" + dbConnectionSuffixRegex + "$"
+
+var dbConnectionIdWithSuffixRegexp = regexp.MustCompile(dbConnectionIdWithSuffixRegex)
 
 func resourceAlicloudDBConnection() *schema.Resource {
 	return &schema.Resource{
@@ -69,8 +76,9 @@ func resourceAlicloudDBConnectionCreate(d *schema.ResourceData, meta interface{}
 }
 
 func resourceAlicloudDBConnectionRead(d *schema.ResourceData, meta interface{}) error {
-	if strings.HasSuffix(d.Id(), DBConnectionSuffix) {
-		d.SetId(strings.Replace(d.Id(), DBConnectionSuffix, "", -1))
+	submatch := dbConnectionIdWithSuffixRegexp.FindStringSubmatch(d.Id())
+	if len(submatch) > 1 {
+		d.SetId(submatch[1])
 	}
 
 	parts := strings.Split(d.Id(), COLON_SEPARATED)
@@ -98,8 +106,9 @@ func resourceAlicloudDBConnectionUpdate(d *schema.ResourceData, meta interface{}
 	client := meta.(*AliyunClient)
 	d.Partial(true)
 
-	if strings.HasSuffix(d.Id(), DBConnectionSuffix) {
-		d.SetId(strings.Replace(d.Id(), DBConnectionSuffix, "", -1))
+	submatch := dbConnectionIdWithSuffixRegexp.FindStringSubmatch(d.Id())
+	if len(submatch) > 1 {
+		d.SetId(submatch[1])
 	}
 
 	parts := strings.Split(d.Id(), COLON_SEPARATED)
@@ -107,7 +116,11 @@ func resourceAlicloudDBConnectionUpdate(d *schema.ResourceData, meta interface{}
 	if d.HasChange("port") && !d.IsNewResource() {
 		request := rds.CreateModifyDBInstanceConnectionStringRequest()
 		request.DBInstanceId = parts[0]
-		request.CurrentConnectionString = fmt.Sprintf("%s%s", parts[1], DBConnectionSuffix)
+		connectionString, err := getCurrentConnectionString(parts[0], meta)
+		if err != nil {
+			return fmt.Errorf("getCurrentConnectionString got error: %#v", err)
+		}
+		request.CurrentConnectionString = connectionString
 		request.ConnectionStringPrefix = parts[1]
 		request.Port = d.Get("port").(string)
 
@@ -143,14 +156,20 @@ func resourceAlicloudDBConnectionUpdate(d *schema.ResourceData, meta interface{}
 
 func resourceAlicloudDBConnectionDelete(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*AliyunClient)
-	if strings.HasSuffix(d.Id(), DBConnectionSuffix) {
-		d.SetId(strings.Replace(d.Id(), DBConnectionSuffix, "", -1))
+
+	submatch := dbConnectionIdWithSuffixRegexp.FindStringSubmatch(d.Id())
+	if len(submatch) > 1 {
+		d.SetId(submatch[1])
 	}
 
 	parts := strings.Split(d.Id(), COLON_SEPARATED)
 
 	return resource.Retry(3*time.Minute, func() *resource.RetryError {
-		err := client.ReleaseDBPublicConnection(parts[0], fmt.Sprintf("%s%s", parts[1], DBConnectionSuffix))
+		connectionString, err := getCurrentConnectionString(parts[0], meta)
+		if err != nil {
+			return resource.NonRetryableError(fmt.Errorf("getCurrentConnectionString got error: %#v", err))
+		}
+		err = client.ReleaseDBPublicConnection(parts[0], connectionString)
 
 		if err != nil {
 			if IsExceptedError(err, InvalidCurrentConnectionStringNotFound) || IsExceptedError(err, AtLeastOneNetTypeExists) {
@@ -174,4 +193,12 @@ func resourceAlicloudDBConnectionDelete(d *schema.ResourceData, meta interface{}
 
 		return resource.RetryableError(fmt.Errorf("Release DB connection timeout."))
 	})
+}
+
+func getCurrentConnectionString(dbInstanceId string, meta interface{}) (string, error) {
+	resp, err := meta.(*AliyunClient).DescribeDBInstanceNetInfoByIpType(dbInstanceId, Public)
+	if err != nil {
+		return "", err
+	}
+	return resp.ConnectionString, nil
 }

--- a/alicloud/resource_alicloud_db_connection_test.go
+++ b/alicloud/resource_alicloud_db_connection_test.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 	"testing"
 
+	"regexp"
+
 	"github.com/aliyun/alibaba-cloud-sdk-go/services/rds"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
@@ -12,6 +14,8 @@ import (
 
 func TestAccAlicloudDBConnection_basic(t *testing.T) {
 	var connection rds.DBInstanceNetInfo
+
+	connectionStringRegexp := regexp.MustCompile("test-connection\\.mysql\\.([a-zA-Z0-9]+\\.){0,1}rds\\.aliyuncs\\.com")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
@@ -29,10 +33,10 @@ func TestAccAlicloudDBConnection_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDBConnectionExists(
 						"alicloud_db_connection.foo", &connection),
-					resource.TestCheckResourceAttr(
+					resource.TestMatchResourceAttr(
 						"alicloud_db_connection.foo",
 						"connection_string",
-						"test-connection.mysql.rds.aliyuncs.com"),
+						connectionStringRegexp),
 					resource.TestCheckResourceAttr(
 						"alicloud_db_connection.foo",
 						"port", "3306"),
@@ -43,10 +47,10 @@ func TestAccAlicloudDBConnection_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDBConnectionExists(
 						"alicloud_db_connection.foo", &connection),
-					resource.TestCheckResourceAttr(
+					resource.TestMatchResourceAttr(
 						"alicloud_db_connection.foo",
 						"connection_string",
-						"test-connection.mysql.rds.aliyuncs.com"),
+						connectionStringRegexp),
 					resource.TestCheckResourceAttr(
 						"alicloud_db_connection.foo",
 						"port", "3333"),
@@ -148,7 +152,7 @@ resource "alicloud_db_connection" "foo" {
 `
 const testAccDBConnection_update = `
 variable "name" {
-	default = "testaccdbconnection_basic"
+	default = "tf-testaccdbconnection_basic"
 }
 data "alicloud_zones" "default" {
 	"available_resource_creation"= "Rds"
@@ -163,6 +167,7 @@ resource "alicloud_vswitch" "foo" {
  	vpc_id = "${alicloud_vpc.foo.id}"
  	cidr_block = "172.16.0.0/21"
  	availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+ 	name = "${var.name}"
 }
 
 resource "alicloud_db_instance" "instance" {


### PR DESCRIPTION
The RDS API has changed the format of DB instance connection URLs from `<custom name>.mysql.rds.aliyuncs.com` to `<custom name>.mysql.<country name>.rds.aliyuncs.com`.

Because of that Terraform is no longer able to update and delete DB instance connections (for example the DBConnectionSuffix constant is invalid).

This pull request fixes this bug and adapts the test TestAccAlicloudDBConnection_basic for the same reason.

Test result:
```
GOROOT=/usr/local/go #gosetup
GOPATH=/Users/marcplouhinec/go #gosetup
/usr/local/go/bin/go test -c -v -sweep=eu-central-1 -o /private/var/folders/v1/jvjz3zmn64q0j34yc9m9n4w00000gn/T/___Test_in_github_com_alibaba_terraform_provider_alicloud -gcflags "all=-N -l" github.com/alibaba/terraform-provider/alicloud #gosetup
/usr/local/go/bin/go tool test2json -t "/Users/marcplouhinec/Library/Application Support/IntelliJIdea2018.1/intellij-go/lib/dlv/mac/dlv" --listen=localhost:62787 --headless=true --api-version=2 --backend=default exec /private/var/folders/v1/jvjz3zmn64q0j34yc9m9n4w00000gn/T/___Test_in_github_com_alibaba_terraform_provider_alicloud -- -test.v -test.run ^TestAccAlicloudDBConnection_basic$ #gosetup
API server listening at: 127.0.0.1:62787
=== RUN   TestAccAlicloudDBConnection_basic
--- PASS: TestAccAlicloudDBConnection_basic (1128.27s)
PASS
```