### PR TITLE
Datasource alicloud oss buckets

### DIFF
--- a/alicloud/data_source_alicloud_oss_buckets.go
+++ b/alicloud/data_source_alicloud_oss_buckets.go
@@ -1,0 +1,339 @@
+package alicloud
+
+import (
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/aliyun/aliyun-oss-go-sdk/oss"
+	"regexp"
+	"fmt"
+	"log"
+)
+
+func dataSourceAlicloudOssBuckets() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAlicloudOssBucketsRead,
+
+		Schema: map[string]*schema.Schema{
+			"name_regex": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validateNameRegex,
+				ForceNew:     true,
+			},
+			"acl": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validateOssBucketAcl,
+			},
+			"output_file": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+
+			// Computed values
+			"buckets": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"acl": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"extranet_endpoint": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"intranet_endpoint": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"location": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"owner": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"storage_class": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"logging_enabled": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"creation_date": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+
+						"cors_rules": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"allowed_headers": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"allowed_methods": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"allowed_origins": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"expose_headers": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"max_age_seconds": {
+										Type:     schema.TypeInt,
+										Computed: true,
+									},
+								},
+							},
+						},
+
+						"website": {
+							Type:     schema.TypeMap,
+							Computed: true,
+						},
+
+						"logging": {
+							Type:     schema.TypeMap,
+							Computed: true,
+						},
+
+						"referer_config": {
+							Type:     schema.TypeMap,
+							Computed: true,
+						},
+
+						"lifecycle_rule": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"id": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"prefix": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"enabled": {
+										Type:     schema.TypeBool,
+										Computed: true,
+									},
+									"expiration": {
+										Type:     schema.TypeMap,
+										Computed: true,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceAlicloudOssBucketsRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*AliyunClient)
+
+	var initialOptions []oss.Option
+	if v, ok := d.GetOk("acl"); ok && v.(string) != "" {
+		acl := oss.ACLType(v.(string))
+		initialOptions = append(initialOptions, oss.ACL(acl))
+	}
+
+	var allBuckets []oss.BucketProperties
+	nextMarker := ""
+	for {
+		var options []oss.Option
+		options = append(options, initialOptions...)
+		if nextMarker != "" {
+			options = append(options, oss.Marker(nextMarker))
+		}
+
+		resp, err := client.ossconn.ListBuckets(options...)
+		if err != nil {
+			return err
+		}
+
+		if resp.Buckets == nil || len(resp.Buckets) < 1 {
+			break
+		}
+
+		allBuckets = append(allBuckets, resp.Buckets...)
+
+		nextMarker = resp.NextMarker
+		if nextMarker == "" {
+			break
+		}
+	}
+
+	var filteredBucketsTemp []oss.BucketProperties
+	nameRegex, ok := d.GetOk("name_regex")
+	if ok && nameRegex.(string) != "" {
+		var r *regexp.Regexp
+		if nameRegex != "" {
+			r = regexp.MustCompile(nameRegex.(string))
+		}
+		for _, bucket := range allBuckets {
+			if r != nil && !r.MatchString(bucket.Name) {
+				continue
+			}
+			filteredBucketsTemp = append(filteredBucketsTemp, bucket)
+		}
+	} else {
+		filteredBucketsTemp = allBuckets
+	}
+
+	if len(filteredBucketsTemp) < 1 {
+		return fmt.Errorf("Your query returned no results. Please change your search criteria and try again.")
+	}
+
+	log.Printf("[DEBUG] alicloud_oss_buckets - Bucket found: %#v", filteredBucketsTemp)
+
+	return bucketsDescriptionAttributes(d, filteredBucketsTemp, meta)
+}
+
+func bucketsDescriptionAttributes(d *schema.ResourceData, buckets []oss.BucketProperties, meta interface{}) error {
+	client := meta.(*AliyunClient)
+
+	var ids []string
+	var s []map[string]interface{}
+	for _, bucket := range buckets {
+		mapping := map[string]interface{}{
+			"name":          bucket.Name,
+			"location":      bucket.Location,
+			"storage_class": bucket.StorageClass,
+			"creation_date": bucket.CreationDate.Format("2016-01-01"),
+		}
+
+		// Add additional information
+		resp, err := client.ossconn.GetBucketInfo(bucket.Name)
+		if err != nil {
+			mapping["acl"] = resp.BucketInfo.ACL
+			mapping["extranet_endpoint"] = resp.BucketInfo.ExtranetEndpoint
+			mapping["intranet_endpoint"] = resp.BucketInfo.IntranetEndpoint
+			mapping["owner"] = resp.BucketInfo.Owner.ID
+		} else {
+			log.Printf("[WARN] Unable to get additional information for the bucket %s: %v", bucket.Name, err)
+		}
+
+		// Add CORS rule information
+		cors, err := client.ossconn.GetBucketCORS(bucket.Name)
+		if err != nil && !IsExceptedErrors(err, []string{NoSuchCORSConfiguration}) {
+			log.Printf("[WARN] Unable to get CORS information for the bucket %s: %v", bucket.Name, err)
+		} else if err == nil && cors.CORSRules != nil {
+			rules := make([]map[string]interface{}, 0, len(cors.CORSRules))
+			for _, rule := range cors.CORSRules {
+				ruleMapping := make(map[string]interface{})
+				ruleMapping["allowed_headers"] = rule.AllowedHeader
+				ruleMapping["allowed_methods"] = rule.AllowedMethod
+				ruleMapping["allowed_origins"] = rule.AllowedOrigin
+				ruleMapping["expose_headers"] = rule.ExposeHeader
+				ruleMapping["max_age_seconds"] = rule.MaxAgeSeconds
+				rules = append(rules, ruleMapping)
+			}
+			mapping["cors_rules"] = rules
+		}
+
+		// Add website configuration
+		ws, err := client.ossconn.GetBucketWebsite(bucket.Name)
+		if err != nil && !IsExceptedErrors(err, []string{NoSuchWebsiteConfiguration}) {
+			log.Printf("[WARN] Unable to get website information for the bucket %s: %v", bucket.Name, err)
+		} else if err == nil && &ws != nil {
+			websiteMapping := make(map[string]interface{})
+			if v := &ws.IndexDocument; v != nil {
+				websiteMapping["index_document"] = v.Suffix
+			}
+			if v := &ws.ErrorDocument; v != nil {
+				websiteMapping["error_document"] = v.Key
+			}
+			mapping["website"] = websiteMapping
+		}
+
+		// Add logging information
+		logEnabled := false
+		logging, err := client.ossconn.GetBucketLogging(bucket.Name)
+		if err != nil {
+			log.Printf("[WARN] Unable to get logging information for the bucket %s: %v", bucket.Name, err)
+		} else if logging.LoggingEnabled.TargetBucket != "" || logging.LoggingEnabled.TargetPrefix != "" {
+			logEnabled = true
+			mapping["logging"] = map[string]interface{}{
+				"target_bucket": logging.LoggingEnabled.TargetBucket,
+				"target_prefix": logging.LoggingEnabled.TargetPrefix,
+			}
+		}
+		mapping["logging_enabled"] = logEnabled
+
+		// Add referer information
+		referer, err := client.ossconn.GetBucketReferer(bucket.Name)
+		if err != nil {
+			log.Printf("[WARN] Unable to get referer information for the bucket %s: %v", bucket.Name, err)
+		} else {
+			mapping["referer_config"] = map[string]interface{}{
+				"allow_empty": referer.AllowEmptyReferer,
+				"referers":    referer.RefererList,
+			}
+		}
+
+		// Add lifecycle information
+		lifecycle, err := client.ossconn.GetBucketLifecycle(bucket.Name)
+		if err != nil {
+			log.Printf("[WARN] Unable to get lifecycle information for the bucket %s: %v", bucket.Name, err)
+		} else if len(lifecycle.Rules) > 0 {
+			ruleMappings := make([]map[string]interface{}, 0, len(lifecycle.Rules))
+
+			for _, lifecycleRule := range lifecycle.Rules {
+				ruleMapping := make(map[string]interface{})
+				ruleMapping["id"] = lifecycleRule.ID
+				ruleMapping["prefix"] = lifecycleRule.Prefix
+				if LifecycleRuleStatus(lifecycleRule.Status) == ExpirationStatusEnabled {
+					ruleMapping["enabled"] = true
+				} else {
+					ruleMapping["enabled"] = false
+				}
+
+				// Expiration
+				expirationMapping := make(map[string]interface{})
+				if !lifecycleRule.Expiration.Date.IsZero() {
+					expirationMapping["date"] = (lifecycleRule.Expiration.Date).Format("2006-01-02")
+				}
+				if &lifecycleRule.Expiration.Days != nil {
+					expirationMapping["days"] = int(lifecycleRule.Expiration.Days)
+				}
+				ruleMapping["expiration"] = expirationMapping
+				ruleMappings = append(ruleMappings, ruleMapping)
+			}
+			mapping["lifecycle_rule"] = ruleMappings
+		}
+
+		log.Printf("[DEBUG] alicloud_oss_buckets - adding bucket mapping: %v", mapping)
+		ids = append(ids, bucket.Name)
+		s = append(s, mapping)
+	}
+
+	d.SetId(dataResourceIdHash(ids))
+	if err := d.Set("instances", s); err != nil {
+		return err
+	}
+
+	// create a json file in current directory and write data source to it.
+	if output, ok := d.GetOk("output_file"); ok && output.(string) != "" {
+		writeToFile(output.(string), s)
+	}
+	return nil
+}

--- a/alicloud/data_source_alicloud_oss_buckets_test.go
+++ b/alicloud/data_source_alicloud_oss_buckets_test.go
@@ -3,28 +3,118 @@ package alicloud
 import (
 	"github.com/hashicorp/terraform/helper/resource"
 	"testing"
+	"fmt"
+	"github.com/hashicorp/terraform/helper/acctest"
 )
 
 func TestAccAlicloudOssBucketsDataSource_basic(t *testing.T) {
+	randInt := acctest.RandInt()
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckAlicloudOssBucketsDataSourceBasic,
+				Config: testAccCheckAlicloudOssBucketsDataSourceBasic(randInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAlicloudDataSourceID("data.alicloud_oss_buckets.balancers"),
-					resource.TestCheckResourceAttr("data.alicloud_oss_buckets.balancers", "slbs.#", "1"),
-					resource.TestCheckResourceAttrSet("data.alicloud_oss_buckets.balancers", "slbs.0.id"),
+					testAccCheckAlicloudDataSourceID("data.alicloud_oss_buckets.buckets"),
+					resource.TestCheckResourceAttr("data.alicloud_oss_buckets.buckets", "buckets.#", "1"),
+					resource.TestCheckResourceAttr("data.alicloud_oss_buckets.buckets", "buckets.0.name", fmt.Sprintf("tf-testacc-bucket-ds-basic-%d", randInt)),
+					resource.TestCheckResourceAttr("data.alicloud_oss_buckets.buckets", "buckets.0.acl", "public-read"),
+					resource.TestCheckResourceAttrSet("data.alicloud_oss_buckets.buckets", "buckets.0.extranet_endpoint"),
+					resource.TestCheckResourceAttrSet("data.alicloud_oss_buckets.buckets", "buckets.0.intranet_endpoint"),
+					resource.TestCheckResourceAttrSet("data.alicloud_oss_buckets.buckets", "buckets.0.location"),
+					resource.TestCheckResourceAttrSet("data.alicloud_oss_buckets.buckets", "buckets.0.owner"),
+					resource.TestCheckResourceAttr("data.alicloud_oss_buckets.buckets", "buckets.0.storage_class", "Standard"),
+					resource.TestCheckResourceAttrSet("data.alicloud_oss_buckets.buckets", "buckets.0.creation_date"),
+					resource.TestCheckResourceAttr("data.alicloud_oss_buckets.buckets", "buckets.0.cors_rules.#", "0"),
+					resource.TestCheckResourceAttr("data.alicloud_oss_buckets.buckets", "buckets.0.website.#", "0"),
+					resource.TestCheckResourceAttr("data.alicloud_oss_buckets.buckets", "buckets.0.logging.#", "0"),
+					resource.TestCheckResourceAttr("data.alicloud_oss_buckets.buckets", "buckets.0.referer_config.#", "1"),
+					resource.TestCheckResourceAttr("data.alicloud_oss_buckets.buckets", "buckets.0.referer_config.0.allow_empty", "true"),
+					resource.TestCheckResourceAttr("data.alicloud_oss_buckets.buckets", "buckets.0.referer_config.0.referers.#", "0"),
+					resource.TestCheckResourceAttr("data.alicloud_oss_buckets.buckets", "buckets.0.lifecycle_rule.#", "0"),
 				),
 			},
 		},
 	})
 }
 
-const testAccCheckAlicloudOssBucketsDataSourceBasic = `
+func TestAccAlicloudOssBucketsDataSource_full(t *testing.T) {
+	randInt := acctest.RandInt()
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckAlicloudOssBucketsDataSourceFull(randInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAlicloudDataSourceID("data.alicloud_oss_buckets.buckets"),
+					resource.TestCheckResourceAttr("data.alicloud_oss_buckets.buckets", "buckets.#", "1"),
+					resource.TestCheckResourceAttr("data.alicloud_oss_buckets.buckets", "buckets.0.name", fmt.Sprintf("tf-testacc-bucket-ds-full-%d-sample", randInt)),
+					resource.TestCheckResourceAttr("data.alicloud_oss_buckets.buckets", "buckets.0.acl", "public-read"),
+					resource.TestCheckResourceAttrSet("data.alicloud_oss_buckets.buckets", "buckets.0.extranet_endpoint"),
+					resource.TestCheckResourceAttrSet("data.alicloud_oss_buckets.buckets", "buckets.0.intranet_endpoint"),
+					resource.TestCheckResourceAttrSet("data.alicloud_oss_buckets.buckets", "buckets.0.location"),
+					resource.TestCheckResourceAttrSet("data.alicloud_oss_buckets.buckets", "buckets.0.owner"),
+					resource.TestCheckResourceAttr("data.alicloud_oss_buckets.buckets", "buckets.0.storage_class", "Standard"),
+					resource.TestCheckResourceAttrSet("data.alicloud_oss_buckets.buckets", "buckets.0.creation_date"),
+
+					resource.TestCheckResourceAttr("data.alicloud_oss_buckets.buckets", "buckets.0.cors_rules.#", "2"),
+					resource.TestCheckResourceAttr("data.alicloud_oss_buckets.buckets", "buckets.0.cors_rules.0.allowed_headers.#", "1"),
+					resource.TestCheckResourceAttr("data.alicloud_oss_buckets.buckets", "buckets.0.cors_rules.0.allowed_headers.0", "authorization"),
+					resource.TestCheckResourceAttr("data.alicloud_oss_buckets.buckets", "buckets.0.cors_rules.0.allowed_methods.#", "2"),
+					resource.TestCheckResourceAttr("data.alicloud_oss_buckets.buckets", "buckets.0.cors_rules.0.allowed_methods.0", "PUT"),
+					resource.TestCheckResourceAttr("data.alicloud_oss_buckets.buckets", "buckets.0.cors_rules.0.allowed_methods.1", "GET"),
+					resource.TestCheckResourceAttr("data.alicloud_oss_buckets.buckets", "buckets.0.cors_rules.0.allowed_origins.#", "1"),
+					resource.TestCheckResourceAttr("data.alicloud_oss_buckets.buckets", "buckets.0.cors_rules.0.allowed_origins.0", "*"),
+					resource.TestCheckResourceAttr("data.alicloud_oss_buckets.buckets", "buckets.0.cors_rules.0.expose_headers.#", "0"),
+					resource.TestCheckResourceAttr("data.alicloud_oss_buckets.buckets", "buckets.0.cors_rules.0.max_age_seconds", "0"),
+
+					resource.TestCheckResourceAttr("data.alicloud_oss_buckets.buckets", "buckets.0.cors_rules.1.allowed_headers.#", "1"),
+					resource.TestCheckResourceAttr("data.alicloud_oss_buckets.buckets", "buckets.0.cors_rules.1.allowed_headers.0", "authorization"),
+					resource.TestCheckResourceAttr("data.alicloud_oss_buckets.buckets", "buckets.0.cors_rules.1.allowed_methods.#", "1"),
+					resource.TestCheckResourceAttr("data.alicloud_oss_buckets.buckets", "buckets.0.cors_rules.1.allowed_methods.0", "GET"),
+					resource.TestCheckResourceAttr("data.alicloud_oss_buckets.buckets", "buckets.0.cors_rules.1.allowed_origins.#", "1"),
+					resource.TestCheckResourceAttr("data.alicloud_oss_buckets.buckets", "buckets.0.cors_rules.1.allowed_origins.0", "http://www.a.com"),
+					resource.TestCheckResourceAttr("data.alicloud_oss_buckets.buckets", "buckets.0.cors_rules.1.expose_headers.#", "1"),
+					resource.TestCheckResourceAttr("data.alicloud_oss_buckets.buckets", "buckets.0.cors_rules.1.expose_headers.0", "x-oss-test"),
+					resource.TestCheckResourceAttr("data.alicloud_oss_buckets.buckets", "buckets.0.cors_rules.1.max_age_seconds", "100"),
+
+					resource.TestCheckResourceAttr("data.alicloud_oss_buckets.buckets", "buckets.0.website.#", "1"),
+					resource.TestCheckResourceAttr("data.alicloud_oss_buckets.buckets", "buckets.0.website.0.index_document", "index.html"),
+					resource.TestCheckResourceAttr("data.alicloud_oss_buckets.buckets", "buckets.0.website.0.error_document", "error.html"),
+
+					resource.TestCheckResourceAttr("data.alicloud_oss_buckets.buckets", "buckets.0.logging.#", "1"),
+					resource.TestCheckResourceAttr("data.alicloud_oss_buckets.buckets", "buckets.0.logging.0.target_bucket", fmt.Sprintf("tf-testacc-bucket-ds-full-%d-log", randInt)),
+					resource.TestCheckResourceAttr("data.alicloud_oss_buckets.buckets", "buckets.0.logging.0.target_prefix", "log/"),
+
+					resource.TestCheckResourceAttr("data.alicloud_oss_buckets.buckets", "buckets.0.referer_config.#", "1"),
+					resource.TestCheckResourceAttr("data.alicloud_oss_buckets.buckets", "buckets.0.referer_config.0.allow_empty", "false"),
+					resource.TestCheckResourceAttr("data.alicloud_oss_buckets.buckets", "buckets.0.referer_config.0.referers.#", "1"),
+					resource.TestCheckResourceAttr("data.alicloud_oss_buckets.buckets", "buckets.0.referer_config.0.referers.0", "http://www.aliyun.com"),
+
+					resource.TestCheckResourceAttr("data.alicloud_oss_buckets.buckets", "buckets.0.lifecycle_rule.#", "2"),
+					resource.TestCheckResourceAttr("data.alicloud_oss_buckets.buckets", "buckets.0.lifecycle_rule.0.id", "rule1"),
+					resource.TestCheckResourceAttr("data.alicloud_oss_buckets.buckets", "buckets.0.lifecycle_rule.0.prefix", "path1/"),
+					resource.TestCheckResourceAttr("data.alicloud_oss_buckets.buckets", "buckets.0.lifecycle_rule.0.enabled", "true"),
+					resource.TestCheckResourceAttr("data.alicloud_oss_buckets.buckets", "buckets.0.lifecycle_rule.0.expiration.#", "1"),
+					resource.TestCheckResourceAttr("data.alicloud_oss_buckets.buckets", "buckets.0.lifecycle_rule.0.expiration.0.days", "365"),
+
+					resource.TestCheckResourceAttr("data.alicloud_oss_buckets.buckets", "buckets.0.lifecycle_rule.1.id", "rule2"),
+					resource.TestCheckResourceAttr("data.alicloud_oss_buckets.buckets", "buckets.0.lifecycle_rule.1.prefix", "path2/"),
+					resource.TestCheckResourceAttr("data.alicloud_oss_buckets.buckets", "buckets.0.lifecycle_rule.1.enabled", "true"),
+					resource.TestCheckResourceAttr("data.alicloud_oss_buckets.buckets", "buckets.0.lifecycle_rule.1.expiration.#", "1"),
+					resource.TestCheckResourceAttr("data.alicloud_oss_buckets.buckets", "buckets.0.lifecycle_rule.1.expiration.0.date", "2018-01-12"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckAlicloudOssBucketsDataSourceBasic(randInt int) string {
+	return fmt.Sprintf(`
 variable "name" {
-	default = "tf-testAccCheckAlicloudOssBucketsDataSourceBasic"
+	default = "tf-testacc-bucket-ds-basic-%d"
 }
 
 resource "alicloud_oss_bucket" "sample_bucket" {
@@ -33,6 +123,77 @@ resource "alicloud_oss_bucket" "sample_bucket" {
 }
 
 data "alicloud_oss_buckets" "buckets" {
-    name_regex = "${alicloud_oss_bucket.sample_bucket.name}"
+    name_regex = "${alicloud_oss_bucket.sample_bucket.bucket}"
 }
-`
+`, randInt)
+}
+
+func testAccCheckAlicloudOssBucketsDataSourceFull(randInt int) string {
+	return fmt.Sprintf(`
+variable "name" {
+	default = "tf-testacc-bucket-ds-full-%d"
+}
+
+resource "alicloud_oss_bucket" "log_bucket"{
+	bucket = "${var.name}-log"
+}
+
+resource "alicloud_oss_bucket" "sample_bucket" {
+	bucket = "${var.name}-sample"
+	acl = "public-read"
+
+    cors_rule = [
+    	{
+			allowed_origins=["*"]
+			allowed_methods=["PUT","GET"]
+			allowed_headers=["authorization"]
+		},
+		{
+			allowed_origins=["http://www.a.com"]
+			allowed_methods=["GET"]
+			allowed_headers=["authorization"]
+			expose_headers=["x-oss-test"]
+			max_age_seconds=100
+		}
+    ]
+
+	website = {
+		index_document = "index.html"
+		error_document = "error.html"
+	}
+
+	logging {
+		target_bucket = "${alicloud_oss_bucket.log_bucket.id}"
+		target_prefix = "log/"
+	}
+
+	referer_config {
+		allow_empty = false
+		referers = ["http://www.aliyun.com"]
+	}
+
+	lifecycle_rule = [
+		{
+			id = "rule1"
+			prefix = "path1/"
+			enabled = true
+			expiration {
+				days = 365
+			}
+		},
+		{
+			id = "rule2"
+			prefix = "path2/"
+			enabled = true
+			expiration {
+				date = "2018-01-12"
+			}
+		}
+	]
+}
+
+data "alicloud_oss_buckets" "buckets" {
+    name_regex = "${alicloud_oss_bucket.sample_bucket.bucket}"
+}
+`, randInt)
+}

--- a/alicloud/data_source_alicloud_oss_buckets_test.go
+++ b/alicloud/data_source_alicloud_oss_buckets_test.go
@@ -1,0 +1,38 @@
+package alicloud
+
+import (
+	"github.com/hashicorp/terraform/helper/resource"
+	"testing"
+)
+
+func TestAccAlicloudOssBucketsDataSource_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckAlicloudOssBucketsDataSourceBasic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAlicloudDataSourceID("data.alicloud_oss_buckets.balancers"),
+					resource.TestCheckResourceAttr("data.alicloud_oss_buckets.balancers", "slbs.#", "1"),
+					resource.TestCheckResourceAttrSet("data.alicloud_oss_buckets.balancers", "slbs.0.id"),
+				),
+			},
+		},
+	})
+}
+
+const testAccCheckAlicloudOssBucketsDataSourceBasic = `
+variable "name" {
+	default = "tf-testAccCheckAlicloudOssBucketsDataSourceBasic"
+}
+
+resource "alicloud_oss_bucket" "sample_bucket" {
+	bucket = "${var.name}"
+	acl = "public-read"
+}
+
+data "alicloud_oss_buckets" "buckets" {
+    name_regex = "${alicloud_oss_bucket.sample_bucket.name}"
+}
+`

--- a/alicloud/provider.go
+++ b/alicloud/provider.go
@@ -96,6 +96,7 @@ func Provider() terraform.ResourceProvider {
 			"alicloud_slb_listeners":        dataSourceAlicloudSlbListeners(),
 			"alicloud_slb_rules":            dataSourceAlicloudSlbRules(),
 			"alicloud_slb_server_groups":    dataSourceAlicloudSlbServerGroups(),
+			"alicloud_oss_buckets":          dataSourceAlicloudOssBuckets(),
 			"alicloud_db_instances":         dataSourceAlicloudDBInstances(),
 			"alicloud_pvtz_zones":           dataSourceAlicloudPvtzZones(),
 			"alicloud_pvtz_zone_records":    dataSourceAlicloudPvtzZoneRecords(),

--- a/website/docs/d/oss_buckets.html.markdown
+++ b/website/docs/d/oss_buckets.html.markdown
@@ -1,0 +1,66 @@
+---
+layout: "alicloud"
+page_title: "Alicloud: alicloud_oss_buckets"
+sidebar_current: "docs-alicloud-datasource-oss-buckets"
+description: |-
+    Provides a list of OSS buckets to the user.
+---
+
+# alicloud\_oss_buckets
+
+This data source provides the OSS buckets of the current Alibaba Cloud user.
+
+## Example Usage
+
+```
+data "alicloud_oss_buckets" "oss_buckets_ds" {
+  name_regex = "sample_oss_bucket"
+}
+
+output "first_oss_bucket_name" {
+  value = "${data.alicloud_oss_buckets.oss_buckets_ds.buckets.0.name}"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name_regex` - (Optional) A regex string to filter results by bucket name.
+* `output_file` - (Optional) File name where to save data source results (after running `terraform plan`).
+
+## Attributes Reference
+
+The following attributes are exported in addition to the arguments listed above:
+
+* `buckets` - A list of buckets. Each element contains the following attributes:
+  * `name` - Bucket name.
+  * `acl` - Bucket access control list. Possible values: `private`, `public-read` and `public-read-write`.
+  * `extranet_endpoint` - Internet domain name for accessing the bucket from outside.
+  * `intranet_endpoint` - Intranet domain name for accessing the bucket from an ECS instance in the same region.
+  * `location` - Region of the data center where the bucket is located.
+  * `owner` - Bucket owner.
+  * `storage_class` - Object storage type. Possible values: `Standard`, `IA` and `Archive`.
+  * `creation_date` - Bucket creation date.
+  * `cors_rules` - A list of CORS rule configurations. Each element contains the following attributes:
+    * `allowed_origins` - The origins allowed for cross-domain requests. Multiple elements can be used to specify multiple allowed origins. Each rule allows up to one wildcard "\*". If "\*" is specified, cross-domain requests of all origins are allowed.
+    * `allowed_methods` - Specify the allowed methods for cross-domain requests. Possible values: `GET`, `PUT`, `DELETE`, `POST` and `HEAD`.
+    * `allowed_headers` - Control whether the headers specified by Access-Control-Request-Headers in the OPTIONS prefetch command are allowed. Each header specified by Access-Control-Request-Headers must match a value in AllowedHeader. Each rule allows up to one wildcard “*” .
+    * `expose_headers` - Specify the response headers allowing users to access from an application (for example, a Javascript XMLHttpRequest object). The wildcard "\*" is not allowed.
+    * `max_age_seconds` - Specify the cache time for the returned result of a browser prefetch (OPTIONS) request to a specific resource.
+  * `website` - A list of one element containing configuration parameters used when the bucket is used as a website. It contains the following attributes:
+    * `index_document` - Key of the HTML document containing the home page.
+    * `error_document` - Key of the HTML document containing the error page.
+  * `logging` - A list of one element containing configuration parameters used for storing access log information. It contains the following attributes:
+    * `target_bucket` - Bucket for storing access logs.
+    * `target_prefix` - Prefix of the saved access log file paths.
+  * `referer_config` - A list of one element containing referer configuration. It contains the following attributes:
+    * `allow_empty` - Indicate whether the access request referer field can be empty.
+    * `referers` - Referer access whitelist.
+  * `lifecycle_rule` - A list CORS of lifecycle configurations. When Lifecycle is enabled, OSS automatically deletes the objects or transitions the objects (to another storage class) corresponding the lifecycle rules on a regular basis. Each element contains the following attributes:
+    * `id` - Unique ID of the rule.
+    * `prefix` - Prefix applicable to a rule. Only those objects with a matching prefix can be affected by the rule.
+    * `enabled` - Indicate whether the rule is enabled or not.
+    * `expiration` - A list of one element containing expiration attributes of an object. It contains the following attributes:
+      * `date` - Date after which the rule to take effect. The format is like 2017-03-09.
+      * `days` - Indicate the number of days after the last object update until the rules take effect.


### PR DESCRIPTION
New data source alicloud_oss_buckets.

Test results:
```
GOROOT=/usr/local/go #gosetup
GOPATH=/Users/marcplouhinec/go #gosetup
/usr/local/go/bin/go test -c -i -v -sweep=cn-beijing -o /private/var/folders/v1/jvjz3zmn64q0j34yc9m9n4w00000gn/T/___Test_in_Beijing__non_verbose_ github.com/alibaba/terraform-provider/alicloud #gosetup
github.com/alibaba/terraform-provider/alicloud
github.com/alibaba/terraform-provider/alicloud (testmain)
/usr/local/go/bin/go tool test2json -t /private/var/folders/v1/jvjz3zmn64q0j34yc9m9n4w00000gn/T/___Test_in_Beijing__non_verbose_ -test.v -test.run ^TestAccAlicloudOssBucketsDataSource_ #gosetup
=== RUN   TestAccAlicloudOssBucketsDataSource_basic
--- PASS: TestAccAlicloudOssBucketsDataSource_basic (9.44s)
=== RUN   TestAccAlicloudOssBucketsDataSource_full
--- PASS: TestAccAlicloudOssBucketsDataSource_full (13.32s)
PASS
```